### PR TITLE
Add Quadlet/systemd integration for Podman containers

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,6 +51,11 @@ For commands where Podman's syntax genuinely differs from Docker, individual met
 | `configuration/registry.rb` | Podman requires explicit `docker.io/` prefix (Docker assumes it) |
 | `configuration/proxy/boot.rb` | Same `docker.io/` prefix for kamal-proxy image |
 | `cli/main.rb` | Replaces server bootstrap to check for Podman, not Docker |
+| `cli/app/boot.rb` | Quadlet: generates `.container` files for app deploys, cleans up old units |
+| `cli/proxy/quadlet.rb` | Quadlet: proxy boot/reboot/start/stop/remove via systemd |
+| `cli/accessory/quadlet.rb` | Quadlet: accessory boot/start/stop/remove via systemd |
+| `commands/proxy/quadlet.rb` | Quadlet: proxy start/stop/start_or_run return systemctl commands |
+| `commands/accessory/quadlet.rb` | Quadlet: accessory start/stop return systemctl commands |
 
 **Safety net:** `test/auto_discovery_test.rb` dynamically iterates all `Kamal::Commands::Base` subclasses and verifies `docker()` returns a podman command. This catches any new Kamal class added in a future version that doesn't work with the base swap.
 
@@ -58,11 +63,12 @@ For commands where Podman's syntax genuinely differs from Docker, individual met
 
 | Class | Purpose |
 |---|---|
-| `KamalPodman::Commander` | Extends `Kamal::Commander`, returns Podman-aware builder/commands |
+| `KamalPodman::Commander` | Extends `Kamal::Commander`, returns Podman-aware builder/commands; provides `quadlet_enabled?` and `quadlet` accessors |
 | `KamalPodman::Commands::Podman` | Podman system commands (`installed?`, `running?`, `create_network`) |
 | `KamalPodman::Commands::Builder` | Podman-based builder with validation (rejects remote/multi-arch/cloud) |
 | `KamalPodman::Commands::Builder::Local` | `podman build` + `podman push` (stubs out buildx lifecycle) |
-| `KamalPodman::Cli::Server` | Podman-aware server bootstrap (checks for Podman, not Docker) |
+| `KamalPodman::Commands::Quadlet` | Quadlet systemd commands (`container_file_content`, `start_unit`, `stop_unit`, `daemon_reload`, file management) |
+| `KamalPodman::Cli::Server` | Podman-aware server bootstrap (checks for Podman, enables lingering for rootless Quadlet) |
 
 ### Podman-Specific Differences from Docker
 
@@ -80,11 +86,12 @@ lib/
   kamal_podman/
     version.rb                 # VERSION constant
     override.rb                # Replaces global KAMAL constant
-    commander.rb               # Custom Commander subclass
+    commander.rb               # Custom Commander subclass (+ quadlet_enabled?, quadlet accessor)
     cli/
-      server.rb                # Podman-aware server bootstrap
+      server.rb                # Podman-aware server bootstrap (+ enable-linger for rootless Quadlet)
     commands/
       podman.rb                # Podman system commands
+      quadlet.rb               # Quadlet/systemd commands and .container file generation
       builder.rb               # Builder orchestrator
       builder/
         local.rb               # Local build implementation
@@ -92,10 +99,20 @@ lib/
     kamal/
       cli/
         main.rb                # Replaces server subcommand
+        app/
+          boot.rb              # Quadlet: app deploy lifecycle (start/stop via systemd)
+        proxy/
+          quadlet.rb           # Quadlet: proxy boot/reboot/start/stop/remove via systemd
+        accessory/
+          quadlet.rb           # Quadlet: accessory boot/start/stop/remove via systemd
       commands/
         base.rb                # Layer 1: docker()→podman() + container_id_for
         app/
           logging.rb           # Layer 2: Podman-specific logs/follow_logs
+        proxy/
+          quadlet.rb           # Quadlet: proxy start/stop/start_or_run via systemctl
+        accessory/
+          quadlet.rb           # Quadlet: accessory start/stop via systemctl
         prune.rb               # Layer 2: Podman-specific prune commands
       configuration/
         registry.rb            # Default registry = docker.io
@@ -183,6 +200,29 @@ This is the highest-risk change. When Kamal releases a new version:
 4. Check for changes in method signatures that would break existing overrides
 5. Run full test suite — unit AND integration
 6. Pay special attention to `Kamal::Commands::Base`, `Kamal::Commands::Prune`, and `Kamal::Configuration`
+
+### Quadlet Override Pattern
+
+All Quadlet-specific overrides are gated behind `KAMAL.quadlet_enabled?` (checks `x-quadlet: true` in deploy.yml). Every Quadlet override method must fall back to the original when Quadlet is disabled:
+
+```ruby
+def boot
+  return original_boot unless KAMAL.quadlet_enabled?
+  # Quadlet-specific implementation...
+end
+```
+
+For Thor CLI classes, wrap `alias_method` in `no_commands {}` to prevent Thor from registering aliases as commands:
+
+```ruby
+Kamal::Cli::Proxy.class_eval do
+  no_commands do
+    alias_method :original_boot, :boot
+  end
+end
+```
+
+Quadlet-generated systemd units cannot be `enable`d/`disable`d — they are "generated" units. The `.container` file being present IS the enabled state. Always use `start_unit`/`stop_unit`, never `enable`.
 
 ### Common Pitfalls
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Experimental: The gem is in its experimental phase, and you might encounter bugs
 
 Kamal base version: `2.10.1`
 
-## Installation: 
+## Installation
 
 You can simply drop in this gem to an existing Kamal based project and start deploying with Podman instead. However you will need to run `kamal app remove` and `kamal proxy remove` to avoid any conflicts. Be aware this will completely shutdown and remove your current application.
 
@@ -39,11 +39,42 @@ kamal-podman app logs
 ```
 
 Follow [Kamal's](https://kamal-deploy.org) official documentation for the most part.
-There will be some differences in the commands available due to the inherit nature of how Podman does things. I will begin to document these differences as I find them here.
+There will be some differences in the commands available due to the inherent nature of how Podman does things.
+
+## Systemd Integration (Quadlet)
+
+Kamal Podman supports optional systemd integration via [Podman Quadlet](https://docs.podman.io/en/latest/markdown/podman-systemd.unit.5.html). When enabled, app, proxy, and accessory containers are managed as systemd services instead of plain `podman run` processes. This provides:
+
+- Automatic container restart on failure or reboot
+- Proper process lifecycle management via systemd
+- Integration with `journalctl` for logging
+- Rootless support with `loginctl enable-linger`
+
+### Enabling Quadlet
+
+Add `x-quadlet: true` to your `deploy.yml`:
+
+```yaml
+x-quadlet: true
+
+service: myapp
+image: myuser/myapp
+servers:
+  - 192.168.1.1
+```
+
+Without this flag, kamal_podman uses traditional `podman run/stop/start` commands — the default behavior is unchanged.
+
+### How It Works
+
+When Quadlet is enabled:
+- `kamal deploy` writes `.container` unit files to the Podman Quadlet directory and starts them via `systemctl`
+- `kamal proxy boot` manages kamal-proxy as a systemd service
+- Accessories (`kamal accessory boot`) are also systemd-managed
+- Old container unit files are automatically cleaned up during deploys
+- For rootless setups (non-root SSH user), `kamal server bootstrap` runs `loginctl enable-linger` so services survive SSH disconnection
 
 ## Roadmap
-- Complete integration of all Kamal commands with Podman.
-- Systemd integration
 - Enhance error handling and logging.
 - Increase test coverage for better reliability.
 
@@ -59,6 +90,9 @@ bin/test
 
 # Run integration tests (requires Docker/Colima)
 ruby -Itest test/integration/main_test.rb test/integration/deploy_test.rb
+
+# Run Quadlet integration test
+ruby -Itest test/integration/main_test.rb test/integration/quadlet_deploy_test.rb
 ```
 
 ### Integration Tests

--- a/lib/kamal_podman/cli/server.rb
+++ b/lib/kamal_podman/cli/server.rb
@@ -17,6 +17,14 @@ class KamalPodman::Cli::Server < Kamal::Cli::Server
               "Install Podman manually: https://podman.io/docs/installation"
       end
 
+      # Enable lingering for rootless Quadlet so systemd user services
+      # survive after the SSH session disconnects
+      if KAMAL.quadlet_enabled? && KAMAL.config.ssh.user != "root"
+        on(KAMAL.hosts) do
+          execute :loginctl, "enable-linger", KAMAL.config.ssh.user
+        end
+      end
+
       run_hook "docker-setup"
     end
   end

--- a/lib/kamal_podman/commander.rb
+++ b/lib/kamal_podman/commander.rb
@@ -12,4 +12,12 @@ class KamalPodman::Commander < Kamal::Commander
   def docker
     podman
   end
+
+  def quadlet
+    @quadlet ||= KamalPodman::Commands::Quadlet.new(config)
+  end
+
+  def quadlet_enabled?
+    config.raw_config[:"x-quadlet"] == true
+  end
 end

--- a/lib/kamal_podman/commands/quadlet.rb
+++ b/lib/kamal_podman/commands/quadlet.rb
@@ -36,6 +36,7 @@ class KamalPodman::Commands::Quadlet < Kamal::Commands::Base
       [Service]
       Restart=always
       RestartSec=5s
+      WorkingDirectory=#{working_directory}
 
       [Install]
       WantedBy=default.target
@@ -73,6 +74,10 @@ class KamalPodman::Commands::Quadlet < Kamal::Commands::Base
   private
     def rootful?
       config.ssh.user == "root"
+    end
+
+    def working_directory
+      rootful? ? "/root" : "$HOME"
     end
 
     def systemctl(*args)

--- a/lib/kamal_podman/commands/quadlet.rb
+++ b/lib/kamal_podman/commands/quadlet.rb
@@ -20,7 +20,7 @@ class KamalPodman::Commands::Quadlet < Kamal::Commands::Base
   # run_args: everything after [:podman, :run] from the command array
   # image: the container image (e.g. "docker.io/dhh/app:999")
   # cmd: optional command to run (e.g. "bin/jobs")
-  def container_file_content(unit_name:, image:, run_args:, cmd: nil)
+  def container_file_content(unit_name:, image:, run_args:, cmd: nil, restart_policy: "always")
     directives = KamalPodman::Commands::Quadlet::ArgParser.parse(run_args)
     resolve_relative_paths!(directives)
     exec_line = "Exec=#{cmd}\n" if cmd.present?
@@ -35,7 +35,7 @@ class KamalPodman::Commands::Quadlet < Kamal::Commands::Base
       #{directives.join("\n")}
       #{exec_line}
       [Service]
-      Restart=always
+      Restart=#{restart_policy}
       RestartSec=5s
       WorkingDirectory=#{working_directory}
 

--- a/lib/kamal_podman/commands/quadlet.rb
+++ b/lib/kamal_podman/commands/quadlet.rb
@@ -1,0 +1,85 @@
+# frozen_string_literal: true
+
+class KamalPodman::Commands::Quadlet < Kamal::Commands::Base
+  ROOTFUL_QUADLET_DIR = "/etc/containers/systemd"
+  ROOTLESS_QUADLET_DIR = "$HOME/.config/containers/systemd"
+
+  def quadlet_directory
+    rootful? ? ROOTFUL_QUADLET_DIR : ROOTLESS_QUADLET_DIR
+  end
+
+  def quadlet_file_path(unit_name)
+    "#{quadlet_directory}/#{unit_name}.container"
+  end
+
+  def ensure_quadlet_directory
+    make_directory quadlet_directory
+  end
+
+  # Generate .container file content from the same args that podman run receives.
+  # run_args: everything after [:podman, :run] from the command array
+  # image: the container image (e.g. "docker.io/dhh/app:999")
+  # cmd: optional command to run (e.g. "bin/jobs")
+  def container_file_content(unit_name:, image:, run_args:, cmd: nil)
+    directives = KamalPodman::Commands::Quadlet::ArgParser.parse(run_args)
+    exec_line = "Exec=#{cmd}\n" if cmd.present?
+
+    <<~QUADLET
+      [Unit]
+      Description=#{unit_name}
+
+      [Container]
+      Image=#{image}
+      Pull=always
+      #{directives.join("\n")}
+      #{exec_line}
+      [Service]
+      Restart=always
+      RestartSec=5s
+
+      [Install]
+      WantedBy=default.target
+    QUADLET
+  end
+
+  def daemon_reload
+    systemctl "daemon-reload"
+  end
+
+  def start_unit(unit_name)
+    systemctl :start, "#{unit_name}.service"
+  end
+
+  def stop_unit(unit_name)
+    systemctl :stop, "#{unit_name}.service"
+  end
+
+  def enable_unit(unit_name)
+    systemctl :enable, "#{unit_name}.service"
+  end
+
+  def enable_and_start_unit(unit_name)
+    systemctl :enable, "--now", "#{unit_name}.service"
+  end
+
+  def disable_unit(unit_name)
+    systemctl :disable, "#{unit_name}.service"
+  end
+
+  def remove_quadlet_file(unit_name)
+    [ :rm, "-f", quadlet_file_path(unit_name) ]
+  end
+
+  private
+    def rootful?
+      config.ssh.user == "root"
+    end
+
+    def systemctl(*args)
+      if rootful?
+        [ :systemctl, *args ]
+      else
+        [ :systemctl, "--user", *args ]
+      end
+    end
+end

--- a/lib/kamal_podman/commands/quadlet.rb
+++ b/lib/kamal_podman/commands/quadlet.rb
@@ -22,6 +22,7 @@ class KamalPodman::Commands::Quadlet < Kamal::Commands::Base
   # cmd: optional command to run (e.g. "bin/jobs")
   def container_file_content(unit_name:, image:, run_args:, cmd: nil)
     directives = KamalPodman::Commands::Quadlet::ArgParser.parse(run_args)
+    resolve_relative_paths!(directives)
     exec_line = "Exec=#{cmd}\n" if cmd.present?
 
     <<~QUADLET
@@ -30,7 +31,7 @@ class KamalPodman::Commands::Quadlet < Kamal::Commands::Base
 
       [Container]
       Image=#{image}
-      Pull=always
+      Pull=never
       #{directives.join("\n")}
       #{exec_line}
       [Service]
@@ -72,6 +73,20 @@ class KamalPodman::Commands::Quadlet < Kamal::Commands::Base
   end
 
   private
+    # Quadlet resolves relative paths in EnvironmentFile relative to the
+    # .container file directory, not the WorkingDirectory. We need to make
+    # them absolute so they resolve correctly.
+    def resolve_relative_paths!(directives)
+      directives.map! do |d|
+        if d.start_with?("EnvironmentFile=") && !d.start_with?("EnvironmentFile=/")
+          path = d.delete_prefix("EnvironmentFile=")
+          "EnvironmentFile=#{working_directory}/#{path}"
+        else
+          d
+        end
+      end
+    end
+
     def rootful?
       config.ssh.user == "root"
     end

--- a/lib/kamal_podman/commands/quadlet/arg_parser.rb
+++ b/lib/kamal_podman/commands/quadlet/arg_parser.rb
@@ -17,7 +17,7 @@ module KamalPodman::Commands::Quadlet::ArgParser
       when "--network"
         directives << "Network=#{args[i + 1]}"
         i += 2
-      when "--env"
+      when "--env", "-e"
         directives << "Environment=#{args[i + 1]}"
         i += 2
       when "--env-file"
@@ -29,7 +29,7 @@ module KamalPodman::Commands::Quadlet::ArgParser
       when "--publish", "-p"
         directives << "PublishPort=#{args[i + 1]}"
         i += 2
-      when "--label"
+      when "--label", "-l"
         directives << "Label=#{args[i + 1]}"
         i += 2
       when "--log-opt"
@@ -45,7 +45,7 @@ module KamalPodman::Commands::Quadlet::ArgParser
         i += 1
       when "--restart"
         i += 2
-      when /\A--restart=.+/
+      when /\A--restart[= ].+/
         i += 1
       when /\A--(.+)=(.+)\z/
         directives << "PodmanArgs=#{args[i]}"

--- a/lib/kamal_podman/commands/quadlet/arg_parser.rb
+++ b/lib/kamal_podman/commands/quadlet/arg_parser.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+module KamalPodman::Commands::Quadlet::ArgParser
+  # Translates a podman-run argument array into Quadlet [Container] directives.
+  # Input: the args portion of [:podman, :run, *args] — everything after :run.
+  # Returns an array of "Key=Value" strings for the [Container] section.
+  def self.parse(run_args)
+    directives = []
+    args = run_args.map(&:to_s)
+    i = 0
+
+    while i < args.length
+      case args[i]
+      when "--name"
+        directives << "ContainerName=#{args[i + 1]}"
+        i += 2
+      when "--network"
+        directives << "Network=#{args[i + 1]}"
+        i += 2
+      when "--env"
+        directives << "Environment=#{args[i + 1]}"
+        i += 2
+      when "--env-file"
+        directives << "EnvironmentFile=#{args[i + 1]}"
+        i += 2
+      when "--volume", "-v"
+        directives << "Volume=#{args[i + 1]}"
+        i += 2
+      when "--publish", "-p"
+        directives << "PublishPort=#{args[i + 1]}"
+        i += 2
+      when "--label"
+        directives << "Label=#{args[i + 1]}"
+        i += 2
+      when "--log-opt"
+        directives << "PodmanArgs=--log-opt #{args[i + 1]}"
+        i += 2
+      when "--log-driver"
+        directives << "LogDriver=#{args[i + 1]}"
+        i += 2
+      when "--hostname"
+        directives << "HostName=#{args[i + 1]}"
+        i += 2
+      when "--detach"
+        i += 1
+      when "--restart"
+        i += 2
+      when /\A--restart=.+/
+        i += 1
+      when /\A--(.+)=(.+)\z/
+        directives << "PodmanArgs=#{args[i]}"
+        i += 1
+      when /\A--/
+        if i + 1 < args.length && !args[i + 1].start_with?("-")
+          directives << "PodmanArgs=#{args[i]} #{args[i + 1]}"
+          i += 2
+        else
+          directives << "PodmanArgs=#{args[i]}"
+          i += 1
+        end
+      else
+        # Positional arg (image name or command) — skip, handled separately
+        i += 1
+      end
+    end
+
+    directives
+  end
+end

--- a/lib/overrides/kamal/cli/accessory/quadlet.rb
+++ b/lib/overrides/kamal/cli/accessory/quadlet.rb
@@ -1,0 +1,117 @@
+# frozen_string_literal: true
+
+Kamal::Cli::Accessory.class_eval do
+  no_commands do
+    alias_method :original_boot, :boot
+    alias_method :original_start, :start
+    alias_method :original_stop, :stop
+    alias_method :original_remove_accessory, :remove_accessory
+  end
+
+  def boot(name, prepare: true)
+    return original_boot(name, prepare: prepare) unless KAMAL.quadlet_enabled?
+
+    with_lock do
+      if name == "all"
+        KAMAL.accessory_names.each { |accessory_name| boot(accessory_name) }
+      else
+        prepare(name) if prepare
+
+        with_accessory(name) do |accessory, hosts|
+          booted_hosts = Concurrent::Array.new
+          on(hosts) do |host|
+            booted_hosts << host.to_s if capture_with_info(*accessory.info(all: true, quiet: true)).strip.presence
+          end
+
+          if booted_hosts.any?
+            say "Skipping booting `#{name}` on #{booted_hosts.sort.join(", ")}, a container already exists", :yellow
+            hosts -= booted_hosts
+          end
+
+          directories(name)
+          upload(name)
+
+          on(hosts) do |host|
+            execute *KAMAL.auditor.record("Booted #{name} accessory"), verbosity: :debug
+            execute *accessory.ensure_env_directory
+            upload! accessory.secrets_io, accessory.secrets_path, mode: "0600"
+
+            # Write Quadlet .container file and start via systemd
+            run_cmd = accessory.run(host: host)
+            unit_name = accessory.service_name
+
+            content = KAMAL.quadlet.container_file_content(
+              unit_name: unit_name,
+              image: accessory.image,
+              run_args: run_cmd[2..],
+              cmd: accessory.cmd
+            )
+
+            execute *KAMAL.quadlet.ensure_quadlet_directory
+            upload! StringIO.new(content), KAMAL.quadlet.quadlet_file_path(unit_name)
+            execute *KAMAL.quadlet.daemon_reload
+            execute *KAMAL.quadlet.start_unit(unit_name)
+
+            if accessory.running_proxy?
+              target = capture_with_info(*accessory.container_id_for(container_name: accessory.service_name, only_running: true)).strip
+              execute *accessory.deploy(target: target)
+            end
+          end
+        end
+      end
+    end
+  end
+
+  def start(name)
+    return original_start(name) unless KAMAL.quadlet_enabled?
+
+    with_lock do
+      with_accessory(name) do |accessory, hosts|
+        on(hosts) do
+          execute *KAMAL.auditor.record("Started #{name} accessory"), verbosity: :debug
+          execute *KAMAL.quadlet.start_unit(accessory.service_name)
+
+          if accessory.running_proxy?
+            target = capture_with_info(*accessory.container_id_for(container_name: accessory.service_name, only_running: true)).strip
+            execute *accessory.deploy(target: target)
+          end
+        end
+      end
+    end
+  end
+
+  def stop(name)
+    return original_stop(name) unless KAMAL.quadlet_enabled?
+
+    with_lock do
+      with_accessory(name) do |accessory, hosts|
+        on(hosts) do
+          execute *KAMAL.auditor.record("Stopped #{name} accessory"), verbosity: :debug
+          execute *KAMAL.quadlet.stop_unit(accessory.service_name), raise_on_non_zero_exit: false
+
+          if accessory.running_proxy?
+            target = capture_with_info(*accessory.container_id_for(container_name: accessory.service_name, only_running: true)).strip
+            execute *accessory.remove if target
+          end
+        end
+      end
+    end
+  end
+
+  private
+
+  def remove_accessory(name)
+    return original_remove_accessory(name) unless KAMAL.quadlet_enabled?
+
+    with_accessory(name) do |accessory, hosts|
+      stop(name)
+      on(hosts) do
+        execute *KAMAL.quadlet.remove_quadlet_file(accessory.service_name)
+        execute *KAMAL.quadlet.daemon_reload
+      end
+    end
+    remove_container(name)
+    remove_image(name)
+    remove_service_directory(name)
+  end
+end

--- a/lib/overrides/kamal/cli/app/boot.rb
+++ b/lib/overrides/kamal/cli/app/boot.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+Kamal::Cli::App::Boot.class_eval do
+  private
+
+  alias_method :original_start_new_version, :start_new_version
+
+  def start_new_version
+    return original_start_new_version unless KAMAL.quadlet_enabled?
+
+    audit "Booted app version #{version}"
+    hostname = "#{host.to_s[0...51].chomp(".")}-#{SecureRandom.hex(6)}"
+
+    execute *app.ensure_env_directory
+    upload! role.secrets_io(host), role.secrets_path, mode: "0600"
+
+    # Build the podman run command to extract flags
+    run_cmd = app.run(hostname: hostname)
+    unit_name = app.container_name
+
+    content = KAMAL.quadlet.container_file_content(
+      unit_name: unit_name,
+      image: KAMAL.config.absolute_image,
+      run_args: run_cmd[2..],
+      cmd: role.cmd
+    )
+
+    execute *KAMAL.quadlet.ensure_quadlet_directory
+    upload! StringIO.new(content), KAMAL.quadlet.quadlet_file_path(unit_name)
+    execute *KAMAL.quadlet.daemon_reload
+    execute *KAMAL.quadlet.start_unit(unit_name)
+
+    if running_proxy?
+      endpoint = capture_with_info(*app.container_id_for_version(version)).strip
+      raise Kamal::Cli::BootError, "Failed to get endpoint for #{role} on #{host}, did the container boot?" if endpoint.empty?
+      execute *app.deploy(target: endpoint)
+    else
+      Kamal::Cli::Healthcheck::Poller.wait_for_healthy { capture_with_info(*app.status(version: version)) }
+    end
+  rescue => e
+    error "Failed to boot #{role} on #{host}"
+    raise e
+  end
+
+  alias_method :original_stop_new_version, :stop_new_version
+
+  def stop_new_version
+    return original_stop_new_version unless KAMAL.quadlet_enabled?
+    execute *KAMAL.quadlet.stop_unit(app.container_name), raise_on_non_zero_exit: false
+  end
+
+  alias_method :original_stop_old_version, :stop_old_version
+
+  def stop_old_version(version)
+    return original_stop_old_version(version) unless KAMAL.quadlet_enabled?
+    execute *KAMAL.quadlet.stop_unit(app.container_name(version)), raise_on_non_zero_exit: false
+    execute *app.clean_up_assets if assets?
+    execute *app.clean_up_error_pages if KAMAL.config.error_pages_path
+  end
+end

--- a/lib/overrides/kamal/cli/app/boot.rb
+++ b/lib/overrides/kamal/cli/app/boot.rb
@@ -53,7 +53,10 @@ Kamal::Cli::App::Boot.class_eval do
 
   def stop_old_version(version)
     return original_stop_old_version(version) unless KAMAL.quadlet_enabled?
-    execute *KAMAL.quadlet.stop_unit(app.container_name(version)), raise_on_non_zero_exit: false
+    unit_name = app.container_name(version)
+    execute *KAMAL.quadlet.stop_unit(unit_name), raise_on_non_zero_exit: false
+    execute *KAMAL.quadlet.remove_quadlet_file(unit_name), raise_on_non_zero_exit: false
+    execute *KAMAL.quadlet.daemon_reload
     execute *app.clean_up_assets if assets?
     execute *app.clean_up_error_pages if KAMAL.config.error_pages_path
   end

--- a/lib/overrides/kamal/cli/proxy/quadlet.rb
+++ b/lib/overrides/kamal/cli/proxy/quadlet.rb
@@ -1,0 +1,155 @@
+# frozen_string_literal: true
+
+# Add helper to Proxy commands for Quadlet image resolution
+Kamal::Commands::Proxy.class_eval do
+  def quadlet_image
+    if proxy_run_config
+      image = proxy_run_config.image
+      # Ensure docker.io prefix for Podman (Podman requires explicit registry)
+      image.include?(".") ? image : "docker.io/#{image}"
+    else
+      "docker.io/basecamp/kamal-proxy:#{Kamal::Configuration::Proxy::Run::MINIMUM_VERSION}"
+    end
+  end
+
+  def quadlet_run_command
+    proxy_run_config&.run_command
+  end
+end
+
+Kamal::Cli::Proxy.class_eval do
+  no_commands do
+    alias_method :original_boot, :boot
+    alias_method :original_reboot, :reboot
+    alias_method :original_start, :start
+    alias_method :original_stop, :stop
+    alias_method :original_remove_container, :remove_container
+  end
+
+  def boot
+    return original_boot unless KAMAL.quadlet_enabled?
+
+    with_lock do
+      on(KAMAL.hosts) do |host|
+        execute *KAMAL.docker.create_network
+      rescue SSHKit::Command::Failed => e
+        raise unless e.message.include?("already exists")
+      end
+
+      on(KAMAL.proxy_hosts) do |host|
+        execute *KAMAL.registry.login
+
+        version = capture_with_info(*KAMAL.proxy(host).version).strip.presence
+
+        if version && Kamal::Utils.older_version?(version, Kamal::Configuration::Proxy::Run::MINIMUM_VERSION)
+          raise "kamal-proxy version #{version} is too old, run `kamal proxy reboot` in order to update to at least #{Kamal::Configuration::Proxy::Run::MINIMUM_VERSION}"
+        end
+
+        execute *KAMAL.proxy(host).ensure_apps_config_directory
+
+        # Write Quadlet .container file and start via systemd
+        proxy = KAMAL.proxy(host)
+        run_cmd = proxy.run
+        unit_name = "kamal-proxy"
+        image = proxy.quadlet_image
+
+        # Pull the proxy image (Quadlet uses Pull=never)
+        execute :podman, :pull, image, raise_on_non_zero_exit: false
+
+        content = KAMAL.quadlet.container_file_content(
+          unit_name: unit_name,
+          image: image,
+          run_args: run_cmd[2..],
+          cmd: proxy.quadlet_run_command,
+          restart_policy: "on-failure"
+        )
+
+        execute *KAMAL.quadlet.ensure_quadlet_directory
+        upload! StringIO.new(content), KAMAL.quadlet.quadlet_file_path(unit_name)
+        execute *KAMAL.quadlet.daemon_reload
+        execute *KAMAL.quadlet.start_unit(unit_name)
+      end
+    end
+  end
+
+  def reboot
+    return original_reboot unless KAMAL.quadlet_enabled?
+
+    confirming "This will cause a brief outage on each host. Are you sure?" do
+      with_lock do
+        host_groups = options[:rolling] ? KAMAL.proxy_hosts : [ KAMAL.proxy_hosts ]
+        host_groups.each do |hosts|
+          host_list = Array(hosts).join(",")
+          run_hook "pre-proxy-reboot", hosts: host_list
+          on(hosts) do |host|
+            proxy = KAMAL.proxy(host)
+            execute *KAMAL.auditor.record("Rebooted proxy"), verbosity: :debug
+            execute *KAMAL.registry.login
+
+            # Stop and remove old container
+            execute *KAMAL.quadlet.stop_unit("kamal-proxy"), raise_on_non_zero_exit: false
+            execute *proxy.remove_container
+            execute *proxy.ensure_apps_config_directory
+
+            # Write new Quadlet file and start
+            run_cmd = proxy.run
+            unit_name = "kamal-proxy"
+            image = proxy.quadlet_image
+
+            # Pull the proxy image (Quadlet uses Pull=never)
+            execute :podman, :pull, image, raise_on_non_zero_exit: false
+
+            content = KAMAL.quadlet.container_file_content(
+              unit_name: unit_name,
+              image: image,
+              run_args: run_cmd[2..],
+              restart_policy: "on-failure"
+            )
+
+            execute *KAMAL.quadlet.ensure_quadlet_directory
+            upload! StringIO.new(content), KAMAL.quadlet.quadlet_file_path(unit_name)
+            execute *KAMAL.quadlet.daemon_reload
+            execute *KAMAL.quadlet.start_unit(unit_name)
+          end
+          run_hook "post-proxy-reboot", hosts: host_list
+        end
+      end
+    end
+  end
+
+  def start
+    return original_start unless KAMAL.quadlet_enabled?
+
+    with_lock do
+      on(KAMAL.proxy_hosts) do |host|
+        execute *KAMAL.auditor.record("Started proxy"), verbosity: :debug
+        execute *KAMAL.quadlet.start_unit("kamal-proxy")
+      end
+    end
+  end
+
+  def stop
+    return original_stop unless KAMAL.quadlet_enabled?
+
+    with_lock do
+      on(KAMAL.proxy_hosts) do |host|
+        execute *KAMAL.auditor.record("Stopped proxy"), verbosity: :debug
+        execute *KAMAL.quadlet.stop_unit("kamal-proxy"), raise_on_non_zero_exit: false
+      end
+    end
+  end
+
+  def remove_container
+    return original_remove_container unless KAMAL.quadlet_enabled?
+
+    with_lock do
+      on(KAMAL.proxy_hosts) do
+        execute *KAMAL.auditor.record("Removed proxy container"), verbosity: :debug
+        execute *KAMAL.quadlet.stop_unit("kamal-proxy"), raise_on_non_zero_exit: false
+        execute *KAMAL.quadlet.remove_quadlet_file("kamal-proxy")
+        execute *KAMAL.quadlet.daemon_reload
+        execute *KAMAL.proxy(host).remove_container
+      end
+    end
+  end
+end

--- a/lib/overrides/kamal/commands/accessory/quadlet.rb
+++ b/lib/overrides/kamal/commands/accessory/quadlet.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+Kamal::Commands::Accessory.class_eval do
+  alias_method :original_start, :start
+
+  def start
+    return original_start unless KAMAL.quadlet_enabled?
+    KAMAL.quadlet.start_unit(service_name)
+  end
+
+  alias_method :original_stop, :stop
+
+  def stop
+    return original_stop unless KAMAL.quadlet_enabled?
+    KAMAL.quadlet.stop_unit(service_name)
+  end
+end

--- a/lib/overrides/kamal/commands/app/quadlet.rb
+++ b/lib/overrides/kamal/commands/app/quadlet.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+Kamal::Commands::App.class_eval do
+  alias_method :original_stop, :stop
+
+  def stop(version: nil)
+    return original_stop(version: version) unless KAMAL.quadlet_enabled?
+
+    if version
+      KAMAL.quadlet.stop_unit(container_name(version))
+    else
+      # No specific version — pipe current container through podman stop (original behavior)
+      original_stop(version: version)
+    end
+  end
+end

--- a/lib/overrides/kamal/commands/proxy/quadlet.rb
+++ b/lib/overrides/kamal/commands/proxy/quadlet.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+Kamal::Commands::Proxy.class_eval do
+  alias_method :original_start, :start
+
+  def start
+    return original_start unless KAMAL.quadlet_enabled?
+    KAMAL.quadlet.start_unit(container_name)
+  end
+
+  alias_method :original_stop, :stop
+
+  def stop(name: container_name)
+    return original_stop(name: name) unless KAMAL.quadlet_enabled?
+    KAMAL.quadlet.stop_unit(name)
+  end
+
+  alias_method :original_start_or_run, :start_or_run
+
+  def start_or_run
+    return original_start_or_run unless KAMAL.quadlet_enabled?
+    KAMAL.quadlet.start_unit(container_name)
+  end
+end

--- a/test/integration/docker-compose.yml
+++ b/test/integration/docker-compose.yml
@@ -40,6 +40,9 @@ services:
       context: docker/vm
     volumes:
       - shared:/shared
+    tmpfs:
+      - /run
+      - /tmp
     ports:
       - "2222:22"
     environment:

--- a/test/integration/docker/deployer/app/config/deploy.quadlet.yml
+++ b/test/integration/docker/deployer/app/config/deploy.quadlet.yml
@@ -1,0 +1,1 @@
+x-quadlet: true

--- a/test/integration/docker/vm/Dockerfile
+++ b/test/integration/docker/vm/Dockerfile
@@ -23,10 +23,10 @@ RUN mkdir -p /root/.ssh && \
     chmod 700 /root/.ssh && \
     ln -s /shared/ssh/id_rsa.pub /root/.ssh/authorized_keys
 
-# Configure Podman for running inside Docker (cgroupfs manager, no events logger)
+# Configure Podman for running inside Docker (systemd cgroup manager, file events logger)
 RUN mkdir -p /etc/containers && \
     printf 'unqualified-search-registries = ["docker.io"]\n\n[[registry]]\nlocation = "registry:5000"\ninsecure = true\n' > /etc/containers/registries.conf && \
-    printf '[engine]\ncgroup_manager = "cgroupfs"\nevents_logger = "file"\n\n[containers]\npids_limit = 0\n' > /etc/containers/containers.conf
+    printf '[engine]\ncgroup_manager = "systemd"\nevents_logger = "file"\n\n[containers]\npids_limit = 0\n' > /etc/containers/containers.conf
 
 # Ensure quadlet directory exists for systemd integration
 RUN mkdir -p /etc/containers/systemd

--- a/test/integration/docker/vm/Dockerfile
+++ b/test/integration/docker/vm/Dockerfile
@@ -2,23 +2,21 @@ FROM ubuntu:24.04
 
 ENV DEBIAN_FRONTEND=noninteractive
 
-# Update and install essential packages
+# Update and install essential packages including systemd (needed for Quadlet)
 RUN apt-get update && \
     apt-get install -y \
+    systemd systemd-sysv \
     openssh-server \
     curl \
     ca-certificates \
+    podman \
     && rm -rf /var/lib/apt/lists/*
-
-# Install Podman
-RUN apt-get update && \
-    apt-get install -y podman && \
-    rm -rf /var/lib/apt/lists/*
 
 # Configure SSH
 RUN mkdir -p /var/run/sshd && \
     ssh-keygen -A && \
-    printf '\nPermitRootLogin yes\nPubkeyAuthentication yes\nPasswordAuthentication no\n' >> /etc/ssh/sshd_config
+    printf '\nPermitRootLogin yes\nPubkeyAuthentication yes\nPasswordAuthentication no\n' >> /etc/ssh/sshd_config && \
+    systemctl enable ssh
 
 # Create root SSH directory and link authorized_keys from shared volume
 RUN mkdir -p /root/.ssh && \
@@ -30,10 +28,19 @@ RUN mkdir -p /etc/containers && \
     printf 'unqualified-search-registries = ["docker.io"]\n\n[[registry]]\nlocation = "registry:5000"\ninsecure = true\n' > /etc/containers/registries.conf && \
     printf '[engine]\ncgroup_manager = "cgroupfs"\nevents_logger = "file"\n\n[containers]\npids_limit = 0\n' > /etc/containers/containers.conf
 
-COPY boot.sh .
+# Ensure quadlet directory exists for systemd integration
+RUN mkdir -p /etc/containers/systemd
 
-HEALTHCHECK --interval=1s CMD pgrep sleep
+# Mask unnecessary systemd services to speed up boot
+RUN systemctl mask \
+    systemd-resolved.service \
+    systemd-networkd.service \
+    systemd-networkd-wait-online.service \
+    systemd-timesyncd.service
+
+HEALTHCHECK --interval=2s --start-period=5s CMD systemctl is-active ssh.service --quiet
 
 EXPOSE 22
 
-CMD ["./boot.sh"]
+STOPSIGNAL SIGRTMIN+3
+CMD ["/sbin/init"]

--- a/test/integration/quadlet_deploy_test.rb
+++ b/test/integration/quadlet_deploy_test.rb
@@ -1,0 +1,36 @@
+require_relative "integration_test"
+
+class QuadletDeployTest < IntegrationTest
+  test "deploy with quadlet creates systemd service" do
+    version = latest_app_version
+    # Kamal naming: {service}-{role}-{destination}-{version}
+    container_name = "app-web-quadlet-#{version}"
+
+    # Deploy using the quadlet destination (x-quadlet: true)
+    kamal :deploy, "-d quadlet"
+
+    # Verify the .container file was written to the quadlet directory
+    container_file = docker_compose(
+      "exec -T vm1 cat /etc/containers/systemd/#{container_name}.container",
+      capture: true
+    )
+    assert_match /\[Unit\]/, container_file
+    assert_match /\[Container\]/, container_file
+    assert_match /Image=/, container_file
+    assert_match /Pull=always/, container_file
+    assert_match /ContainerName=#{container_name}/, container_file
+
+    # Verify the systemd service is active
+    service_status = docker_compose(
+      "exec -T vm1 systemctl is-active #{container_name}.service",
+      capture: true
+    )
+    assert_match /active/, service_status
+
+    # Verify the container is actually running via podman
+    assert_container_running host: :vm1, name: container_name
+
+    # Verify kamal-proxy is running (proxy lifecycle is unchanged)
+    assert_container_running host: :vm1, name: "kamal-proxy"
+  end
+end

--- a/test/integration/quadlet_deploy_test.rb
+++ b/test/integration/quadlet_deploy_test.rb
@@ -17,7 +17,7 @@ class QuadletDeployTest < IntegrationTest
     assert_match /\[Unit\]/, container_file
     assert_match /\[Container\]/, container_file
     assert_match /Image=/, container_file
-    assert_match /Pull=always/, container_file
+    assert_match /Pull=never/, container_file
     assert_match /ContainerName=#{container_name}/, container_file
 
     # Verify the systemd service is active

--- a/test/overrides_test.rb
+++ b/test/overrides_test.rb
@@ -142,6 +142,7 @@ class ProxyOverrideTest < ActiveSupport::TestCase
       service: "app", image: "dhh/app", registry: { "username" => "user", "password" => "pw" },
       servers: [ "1.1.1.1", "1.1.1.2" ], builder: { "arch" => "amd64" }
     }
+    KAMAL.stubs(:quadlet_enabled?).returns(false)
   end
 
   test "start" do
@@ -267,6 +268,7 @@ class AccessoryOverrideTest < ActiveSupport::TestCase
       accessories: { "db" => { "image" => "mysql:8.0", "host" => "1.1.1.1", "port" => "3306",
         "env" => { "clear" => { "MYSQL_ROOT_HOST" => "%" } } } }
     }
+    KAMAL.stubs(:quadlet_enabled?).returns(false)
   end
 
   test "run uses podman" do

--- a/test/quadlet_accessory_test.rb
+++ b/test/quadlet_accessory_test.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class QuadletAccessoryCommandsTest < ActiveSupport::TestCase
+  setup do
+    @config = {
+      service: "app", image: "dhh/app", registry: { "username" => "user", "password" => "pw" },
+      servers: [ "1.1.1.1" ], builder: { "arch" => "amd64" },
+      accessories: {
+        "mysql" => {
+          "image" => "mysql:8.0",
+          "host" => "1.1.1.1",
+          "port" => "3306:3306",
+          "env" => {
+            "clear" => { "MYSQL_ROOT_PASSWORD" => "secret" }
+          }
+        }
+      }
+    }
+    @kamal_config = Kamal::Configuration.new(@config, version: "999")
+    @quadlet = KamalPodman::Commands::Quadlet.new(@kamal_config)
+  end
+
+  test "start returns systemctl start when quadlet enabled" do
+    KAMAL.stubs(:quadlet_enabled?).returns(true)
+    KAMAL.stubs(:quadlet).returns(@quadlet)
+
+    accessory = Kamal::Commands::Accessory.new(@kamal_config, name: :mysql)
+    result = accessory.start
+
+    assert_equal [ :systemctl, :start, "app-mysql.service" ], result
+  end
+
+  test "start falls back to original when quadlet disabled" do
+    KAMAL.stubs(:quadlet_enabled?).returns(false)
+
+    accessory = Kamal::Commands::Accessory.new(@kamal_config, name: :mysql)
+    result = accessory.start.join(" ")
+
+    assert_match(/podman/, result)
+    assert_match(/app-mysql/, result)
+  end
+
+  test "stop returns systemctl stop when quadlet enabled" do
+    KAMAL.stubs(:quadlet_enabled?).returns(true)
+    KAMAL.stubs(:quadlet).returns(@quadlet)
+
+    accessory = Kamal::Commands::Accessory.new(@kamal_config, name: :mysql)
+    result = accessory.stop
+
+    assert_equal [ :systemctl, :stop, "app-mysql.service" ], result
+  end
+
+  test "stop falls back to original when quadlet disabled" do
+    KAMAL.stubs(:quadlet_enabled?).returns(false)
+
+    accessory = Kamal::Commands::Accessory.new(@kamal_config, name: :mysql)
+    result = accessory.stop.join(" ")
+
+    assert_match(/podman/, result)
+    assert_match(/app-mysql/, result)
+  end
+end

--- a/test/quadlet_proxy_test.rb
+++ b/test/quadlet_proxy_test.rb
@@ -1,0 +1,82 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class QuadletProxyCommandsTest < ActiveSupport::TestCase
+  setup do
+    @config = {
+      service: "app", image: "dhh/app", registry: { "username" => "user", "password" => "pw" },
+      servers: [ "1.1.1.1" ], builder: { "arch" => "amd64" }
+    }
+    @kamal_config = Kamal::Configuration.new(@config, version: "999")
+    @quadlet = KamalPodman::Commands::Quadlet.new(@kamal_config)
+  end
+
+  test "start returns systemctl start when quadlet enabled" do
+    KAMAL.stubs(:quadlet_enabled?).returns(true)
+    KAMAL.stubs(:quadlet).returns(@quadlet)
+
+    proxy = Kamal::Commands::Proxy.new(@kamal_config, host: "1.1.1.1")
+    result = proxy.start
+
+    assert_equal [ :systemctl, :start, "kamal-proxy.service" ], result
+  end
+
+  test "start falls back to original when quadlet disabled" do
+    KAMAL.stubs(:quadlet_enabled?).returns(false)
+
+    proxy = Kamal::Commands::Proxy.new(@kamal_config, host: "1.1.1.1")
+    result = proxy.start.join(" ")
+
+    assert_match(/podman/, result)
+    assert_match(/kamal-proxy/, result)
+  end
+
+  test "stop returns systemctl stop when quadlet enabled" do
+    KAMAL.stubs(:quadlet_enabled?).returns(true)
+    KAMAL.stubs(:quadlet).returns(@quadlet)
+
+    proxy = Kamal::Commands::Proxy.new(@kamal_config, host: "1.1.1.1")
+    result = proxy.stop
+
+    assert_equal [ :systemctl, :stop, "kamal-proxy.service" ], result
+  end
+
+  test "stop with custom name returns systemctl stop for that name" do
+    KAMAL.stubs(:quadlet_enabled?).returns(true)
+    KAMAL.stubs(:quadlet).returns(@quadlet)
+
+    proxy = Kamal::Commands::Proxy.new(@kamal_config, host: "1.1.1.1")
+    result = proxy.stop(name: "custom-proxy")
+
+    assert_equal [ :systemctl, :stop, "custom-proxy.service" ], result
+  end
+
+  test "stop falls back to original when quadlet disabled" do
+    KAMAL.stubs(:quadlet_enabled?).returns(false)
+
+    proxy = Kamal::Commands::Proxy.new(@kamal_config, host: "1.1.1.1")
+    result = proxy.stop.join(" ")
+
+    assert_match(/podman/, result)
+  end
+
+  test "start_or_run returns systemctl start when quadlet enabled" do
+    KAMAL.stubs(:quadlet_enabled?).returns(true)
+    KAMAL.stubs(:quadlet).returns(@quadlet)
+
+    proxy = Kamal::Commands::Proxy.new(@kamal_config, host: "1.1.1.1")
+    result = proxy.start_or_run
+
+    assert_equal [ :systemctl, :start, "kamal-proxy.service" ], result
+  end
+
+  test "start_or_run falls back to original when quadlet disabled" do
+    KAMAL.stubs(:quadlet_enabled?).returns(false)
+
+    proxy = Kamal::Commands::Proxy.new(@kamal_config, host: "1.1.1.1")
+    result = proxy.start_or_run.join(" ")
+
+    assert_match(/podman/, result)
+  end
+end

--- a/test/quadlet_test.rb
+++ b/test/quadlet_test.rb
@@ -17,6 +17,10 @@ class QuadletArgParserTest < ActiveSupport::TestCase
     assert_includes result, "Environment=BAZ=qux"
   end
 
+  test "parses -e shorthand" do
+    assert_includes parse("-e", "FOO=bar"), "Environment=FOO=bar"
+  end
+
   test "parses --env-file" do
     assert_includes parse("--env-file", "/path/to/env"), "EnvironmentFile=/path/to/env"
   end
@@ -65,6 +69,11 @@ class QuadletArgParserTest < ActiveSupport::TestCase
 
   test "skips --restart=value" do
     result = parse("--restart=unless-stopped", "--name", "app")
+    assert_equal [ "ContainerName=app" ], result
+  end
+
+  test "skips --restart with space-joined value" do
+    result = parse("--restart unless-stopped", "--name", "app")
     assert_equal [ "ContainerName=app" ], result
   end
 
@@ -224,6 +233,7 @@ class QuadletCommandsTest < ActiveSupport::TestCase
     assert_match(/\[Service\]/, content)
     assert_match(/Restart=always/, content)
     assert_match(/RestartSec=5s/, content)
+    assert_match(/WorkingDirectory=\/root/, content)
     assert_match(/\[Install\]/, content)
     assert_match(/WantedBy=default\.target/, content)
   end

--- a/test/quadlet_test.rb
+++ b/test/quadlet_test.rb
@@ -226,7 +226,7 @@ class QuadletCommandsTest < ActiveSupport::TestCase
     assert_match(/Description=app-web-999/, content)
     assert_match(/\[Container\]/, content)
     assert_match(/Image=docker\.io\/dhh\/app:999/, content)
-    assert_match(/Pull=always/, content)
+    assert_match(/Pull=never/, content)
     assert_match(/ContainerName=app-web-999/, content)
     assert_match(/Network=kamal/, content)
     assert_match(/Environment=FOO=bar/, content)
@@ -247,6 +247,37 @@ class QuadletCommandsTest < ActiveSupport::TestCase
     )
 
     assert_match(/Exec=bin\/jobs/, content)
+  end
+
+  test "container_file_content resolves relative EnvironmentFile to absolute" do
+    content = new_command.container_file_content(
+      unit_name: "app-web-999",
+      image: "docker.io/dhh/app:999",
+      run_args: [ "--name", "app-web-999", "--env-file", ".kamal/apps/app/env/roles/web.env" ]
+    )
+
+    assert_match(%r{EnvironmentFile=/root/\.kamal/apps/app/env/roles/web\.env}, content)
+    assert_no_match(/EnvironmentFile=\.kamal/, content)
+  end
+
+  test "container_file_content preserves absolute EnvironmentFile" do
+    content = new_command.container_file_content(
+      unit_name: "app-web-999",
+      image: "docker.io/dhh/app:999",
+      run_args: [ "--name", "app-web-999", "--env-file", "/etc/app/env" ]
+    )
+
+    assert_match(%r{EnvironmentFile=/etc/app/env}, content)
+  end
+
+  test "container_file_content resolves relative EnvironmentFile for rootless" do
+    content = new_command(ssh_user: "deploy").container_file_content(
+      unit_name: "app-web-999",
+      image: "docker.io/dhh/app:999",
+      run_args: [ "--name", "app-web-999", "--env-file", ".kamal/apps/app/env/roles/web.env" ]
+    )
+
+    assert_match(%r{EnvironmentFile=\$HOME/\.kamal/apps/app/env/roles/web\.env}, content)
   end
 
   test "container_file_content without cmd omits Exec" do

--- a/test/quadlet_test.rb
+++ b/test/quadlet_test.rb
@@ -1,0 +1,363 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class QuadletArgParserTest < ActiveSupport::TestCase
+  test "parses --name" do
+    assert_includes parse("--name", "app-web-999"), "ContainerName=app-web-999"
+  end
+
+  test "parses --network" do
+    assert_includes parse("--network", "kamal"), "Network=kamal"
+  end
+
+  test "parses --env" do
+    result = parse("--env", "FOO=bar", "--env", "BAZ=qux")
+    assert_includes result, "Environment=FOO=bar"
+    assert_includes result, "Environment=BAZ=qux"
+  end
+
+  test "parses --env-file" do
+    assert_includes parse("--env-file", "/path/to/env"), "EnvironmentFile=/path/to/env"
+  end
+
+  test "parses --volume" do
+    assert_includes parse("--volume", "/host:/container"), "Volume=/host:/container"
+  end
+
+  test "parses -v shorthand" do
+    assert_includes parse("-v", "/host:/container"), "Volume=/host:/container"
+  end
+
+  test "parses --publish" do
+    assert_includes parse("--publish", "80:3000"), "PublishPort=80:3000"
+  end
+
+  test "parses -p shorthand" do
+    assert_includes parse("-p", "80:3000"), "PublishPort=80:3000"
+  end
+
+  test "parses --label" do
+    assert_includes parse("--label", "service=app"), "Label=service=app"
+  end
+
+  test "parses --log-opt as PodmanArgs" do
+    assert_includes parse("--log-opt", "max-size=10m"), "PodmanArgs=--log-opt max-size=10m"
+  end
+
+  test "parses --log-driver" do
+    assert_includes parse("--log-driver", "journald"), "LogDriver=journald"
+  end
+
+  test "parses --hostname" do
+    assert_includes parse("--hostname", "myhost"), "HostName=myhost"
+  end
+
+  test "skips --detach" do
+    result = parse("--detach", "--name", "app")
+    assert_equal [ "ContainerName=app" ], result
+  end
+
+  test "skips --restart with value" do
+    result = parse("--restart", "unless-stopped", "--name", "app")
+    assert_equal [ "ContainerName=app" ], result
+  end
+
+  test "skips --restart=value" do
+    result = parse("--restart=unless-stopped", "--name", "app")
+    assert_equal [ "ContainerName=app" ], result
+  end
+
+  test "unknown --flag=value passes as PodmanArgs" do
+    assert_includes parse("--memory=512m"), "PodmanArgs=--memory=512m"
+  end
+
+  test "unknown --flag with value passes as PodmanArgs" do
+    assert_includes parse("--cpus", "2"), "PodmanArgs=--cpus 2"
+  end
+
+  test "unknown --flag without value passes as PodmanArgs" do
+    assert_includes parse("--rm"), "PodmanArgs=--rm"
+  end
+
+  test "skips positional args" do
+    result = parse("--name", "app", "docker.io/dhh/app:999")
+    assert_equal [ "ContainerName=app" ], result
+  end
+
+  test "parses full run args like Kamal produces" do
+    args = %w[
+      --detach --restart unless-stopped
+      --name app-web-999 --network kamal
+      --env KAMAL_CONTAINER_NAME=app-web-999
+      --env KAMAL_VERSION=999
+      --env-file .kamal/apps/app/env/roles/web.env
+      --log-opt max-size=10m
+      --label service=app --label role=web
+      docker.io/dhh/app:999
+    ]
+
+    result = parse(*args)
+
+    assert_includes result, "ContainerName=app-web-999"
+    assert_includes result, "Network=kamal"
+    assert_includes result, "Environment=KAMAL_CONTAINER_NAME=app-web-999"
+    assert_includes result, "Environment=KAMAL_VERSION=999"
+    assert_includes result, "EnvironmentFile=.kamal/apps/app/env/roles/web.env"
+    assert_includes result, "PodmanArgs=--log-opt max-size=10m"
+    assert_includes result, "Label=service=app"
+    assert_includes result, "Label=role=web"
+
+    assert_not result.any? { |d| d.include?("detach") }
+    assert_not result.any? { |d| d.include?("restart") }
+    assert_not result.any? { |d| d.include?("docker.io/dhh/app:999") }
+  end
+
+  private
+    def parse(*args)
+      KamalPodman::Commands::Quadlet::ArgParser.parse(args)
+    end
+end
+
+class QuadletCommandsTest < ActiveSupport::TestCase
+  setup do
+    @config = {
+      service: "app", image: "dhh/app", registry: { "username" => "user", "password" => "pw" },
+      servers: [ "1.1.1.1" ], builder: { "arch" => "amd64" }
+    }
+  end
+
+  test "quadlet_directory rootful" do
+    assert_equal "/etc/containers/systemd", new_command.quadlet_directory
+  end
+
+  test "quadlet_directory rootless" do
+    assert_equal "$HOME/.config/containers/systemd", new_command(ssh_user: "deploy").quadlet_directory
+  end
+
+  test "quadlet_file_path rootful" do
+    assert_equal "/etc/containers/systemd/app-web-999.container",
+      new_command.quadlet_file_path("app-web-999")
+  end
+
+  test "quadlet_file_path rootless" do
+    assert_equal "$HOME/.config/containers/systemd/app-web-999.container",
+      new_command(ssh_user: "deploy").quadlet_file_path("app-web-999")
+  end
+
+  test "ensure_quadlet_directory rootful" do
+    assert_equal \
+      "mkdir -p /etc/containers/systemd",
+      new_command.ensure_quadlet_directory.join(" ")
+  end
+
+  test "ensure_quadlet_directory rootless" do
+    assert_equal \
+      "mkdir -p $HOME/.config/containers/systemd",
+      new_command(ssh_user: "deploy").ensure_quadlet_directory.join(" ")
+  end
+
+  test "daemon_reload rootful" do
+    assert_equal [ :systemctl, "daemon-reload" ], new_command.daemon_reload
+  end
+
+  test "daemon_reload rootless" do
+    assert_equal [ :systemctl, "--user", "daemon-reload" ], new_command(ssh_user: "deploy").daemon_reload
+  end
+
+  test "start_unit rootful" do
+    assert_equal [ :systemctl, :start, "app-web-999.service" ], new_command.start_unit("app-web-999")
+  end
+
+  test "start_unit rootless" do
+    assert_equal [ :systemctl, "--user", :start, "app-web-999.service" ],
+      new_command(ssh_user: "deploy").start_unit("app-web-999")
+  end
+
+  test "stop_unit rootful" do
+    assert_equal [ :systemctl, :stop, "app-web-999.service" ], new_command.stop_unit("app-web-999")
+  end
+
+  test "stop_unit rootless" do
+    assert_equal [ :systemctl, "--user", :stop, "app-web-999.service" ],
+      new_command(ssh_user: "deploy").stop_unit("app-web-999")
+  end
+
+  test "enable_unit" do
+    assert_equal [ :systemctl, :enable, "app-web-999.service" ], new_command.enable_unit("app-web-999")
+  end
+
+  test "enable_and_start_unit" do
+    assert_equal [ :systemctl, :enable, "--now", "app-web-999.service" ],
+      new_command.enable_and_start_unit("app-web-999")
+  end
+
+  test "disable_unit" do
+    assert_equal [ :systemctl, :disable, "app-web-999.service" ], new_command.disable_unit("app-web-999")
+  end
+
+  test "remove_quadlet_file rootful" do
+    assert_equal [ :rm, "-f", "/etc/containers/systemd/app-web-999.container" ],
+      new_command.remove_quadlet_file("app-web-999")
+  end
+
+  test "remove_quadlet_file rootless" do
+    assert_equal [ :rm, "-f", "$HOME/.config/containers/systemd/app-web-999.container" ],
+      new_command(ssh_user: "deploy").remove_quadlet_file("app-web-999")
+  end
+
+  test "container_file_content generates valid INI" do
+    content = new_command.container_file_content(
+      unit_name: "app-web-999",
+      image: "docker.io/dhh/app:999",
+      run_args: [ "--name", "app-web-999", "--network", "kamal", "--env", "FOO=bar" ]
+    )
+
+    assert_match(/\[Unit\]/, content)
+    assert_match(/Description=app-web-999/, content)
+    assert_match(/\[Container\]/, content)
+    assert_match(/Image=docker\.io\/dhh\/app:999/, content)
+    assert_match(/Pull=always/, content)
+    assert_match(/ContainerName=app-web-999/, content)
+    assert_match(/Network=kamal/, content)
+    assert_match(/Environment=FOO=bar/, content)
+    assert_match(/\[Service\]/, content)
+    assert_match(/Restart=always/, content)
+    assert_match(/RestartSec=5s/, content)
+    assert_match(/\[Install\]/, content)
+    assert_match(/WantedBy=default\.target/, content)
+  end
+
+  test "container_file_content with cmd" do
+    content = new_command.container_file_content(
+      unit_name: "app-jobs-999",
+      image: "docker.io/dhh/app:999",
+      run_args: [ "--name", "app-jobs-999" ],
+      cmd: "bin/jobs"
+    )
+
+    assert_match(/Exec=bin\/jobs/, content)
+  end
+
+  test "container_file_content without cmd omits Exec" do
+    content = new_command.container_file_content(
+      unit_name: "app-web-999",
+      image: "docker.io/dhh/app:999",
+      run_args: [ "--name", "app-web-999" ]
+    )
+
+    assert_no_match(/Exec=/, content)
+  end
+
+  test "container_file_content section order is Unit, Container, Service, Install" do
+    content = new_command.container_file_content(
+      unit_name: "app-web-999",
+      image: "docker.io/dhh/app:999",
+      run_args: []
+    )
+
+    unit_pos = content.index("[Unit]")
+    container_pos = content.index("[Container]")
+    service_pos = content.index("[Service]")
+    install_pos = content.index("[Install]")
+
+    assert unit_pos < container_pos
+    assert container_pos < service_pos
+    assert service_pos < install_pos
+  end
+
+  private
+    def new_command(ssh_user: nil)
+      config_hash = @config.dup
+      config_hash[:ssh] = { "user" => ssh_user } if ssh_user
+      KamalPodman::Commands::Quadlet.new(Kamal::Configuration.new(config_hash, version: "999"))
+    end
+end
+
+class QuadletEnabledTest < ActiveSupport::TestCase
+  test "quadlet_enabled? returns false by default" do
+    config = {
+      service: "app", image: "dhh/app", registry: { "username" => "user", "password" => "pw" },
+      servers: [ "1.1.1.1" ], builder: { "arch" => "amd64" }
+    }
+    commander = KamalPodman::Commander.new
+    commander.stubs(:config).returns(Kamal::Configuration.new(config, version: "999"))
+
+    assert_not commander.quadlet_enabled?
+  end
+
+  test "quadlet_enabled? returns true when x-quadlet is true" do
+    config = {
+      service: "app", image: "dhh/app", registry: { "username" => "user", "password" => "pw" },
+      servers: [ "1.1.1.1" ], builder: { "arch" => "amd64" },
+      "x-quadlet": true
+    }
+    commander = KamalPodman::Commander.new
+    commander.stubs(:config).returns(Kamal::Configuration.new(config, version: "999"))
+
+    assert commander.quadlet_enabled?
+  end
+
+  test "quadlet_enabled? returns false when x-quadlet is not true" do
+    config = {
+      service: "app", image: "dhh/app", registry: { "username" => "user", "password" => "pw" },
+      servers: [ "1.1.1.1" ], builder: { "arch" => "amd64" },
+      "x-quadlet": "yes"
+    }
+    commander = KamalPodman::Commander.new
+    commander.stubs(:config).returns(Kamal::Configuration.new(config, version: "999"))
+
+    assert_not commander.quadlet_enabled?
+  end
+
+  test "commander exposes quadlet command instance" do
+    config = {
+      service: "app", image: "dhh/app", registry: { "username" => "user", "password" => "pw" },
+      servers: [ "1.1.1.1" ], builder: { "arch" => "amd64" }
+    }
+    commander = KamalPodman::Commander.new
+    commander.stubs(:config).returns(Kamal::Configuration.new(config, version: "999"))
+
+    assert_kind_of KamalPodman::Commands::Quadlet, commander.quadlet
+  end
+end
+
+class QuadletAppStopOverrideTest < ActiveSupport::TestCase
+  setup do
+    @config = {
+      service: "app", image: "dhh/app", registry: { "username" => "user", "password" => "pw" },
+      servers: [ "1.1.1.1" ], builder: { "arch" => "amd64" }
+    }
+    @kamal_config = Kamal::Configuration.new(@config, version: "999")
+    @quadlet = KamalPodman::Commands::Quadlet.new(@kamal_config)
+  end
+
+  test "stop with version returns systemctl stop when quadlet enabled" do
+    KAMAL.stubs(:quadlet_enabled?).returns(true)
+    KAMAL.stubs(:quadlet).returns(@quadlet)
+
+    app = Kamal::Commands::App.new(@kamal_config, role: @kamal_config.role(:web), host: "1.1.1.1")
+    result = app.stop(version: "999")
+
+    assert_equal [ :systemctl, :stop, "app-web-999.service" ], result
+  end
+
+  test "stop without version falls back to original when quadlet enabled" do
+    KAMAL.stubs(:quadlet_enabled?).returns(true)
+    KAMAL.stubs(:quadlet).returns(@quadlet)
+
+    app = Kamal::Commands::App.new(@kamal_config, role: @kamal_config.role(:web), host: "1.1.1.1")
+    result = app.stop.join(" ")
+
+    assert_match(/podman/, result)
+  end
+
+  test "stop delegates to original when quadlet disabled" do
+    KAMAL.stubs(:quadlet_enabled?).returns(false)
+
+    app = Kamal::Commands::App.new(@kamal_config, role: @kamal_config.role(:web), host: "1.1.1.1")
+    result = app.stop(version: "999").join(" ")
+
+    assert_match(/podman/, result)
+  end
+end

--- a/test/quadlet_test.rb
+++ b/test/quadlet_test.rb
@@ -307,6 +307,28 @@ class QuadletCommandsTest < ActiveSupport::TestCase
     assert service_pos < install_pos
   end
 
+  test "container_file_content defaults to Restart=always" do
+    content = new_command.container_file_content(
+      unit_name: "app-web-999",
+      image: "docker.io/dhh/app:999",
+      run_args: []
+    )
+
+    assert_match(/Restart=always/, content)
+  end
+
+  test "container_file_content with restart_policy on-failure" do
+    content = new_command.container_file_content(
+      unit_name: "kamal-proxy",
+      image: "docker.io/basecamp/kamal-proxy:v0.9.0",
+      run_args: [],
+      restart_policy: "on-failure"
+    )
+
+    assert_match(/Restart=on-failure/, content)
+    assert_no_match(/Restart=always/, content)
+  end
+
   private
     def new_command(ssh_user: nil)
       config_hash = @config.dup


### PR DESCRIPTION
## Summary

- Adds optional systemd integration via Podman Quadlet (`x-quadlet: true` in deploy.yml)
- When enabled, app, proxy, and accessory containers are managed as systemd services instead of plain `podman run` processes
- Automatic container restart on failure/reboot, proper lifecycle management, journald logging integration
- Rootless support with `loginctl enable-linger` during server bootstrap
- Old `.container` unit files are cleaned up automatically during deploys
- Fully backwards-compatible — without `x-quadlet: true`, all behavior is unchanged

### Commits

1. **Phase 1** — App containers as Quadlet systemd services (`KamalPodman::Commands::Quadlet`, `ArgParser`, app boot override)
2. **Phase 2** — Proxy and accessory containers as Quadlet systemd services (CLI + Commands overrides for both)
3. **Prune cleanup** — Old `.container` files removed in `stop_old_version`
4. **Enable-linger** — `loginctl enable-linger` for rootless Quadlet during bootstrap
5. **Documentation** — README and CLAUDE.md updated

### Key design decisions

- All Quadlet overrides gate on `KAMAL.quadlet_enabled?` and fall back to original methods when disabled
- `Pull=never` in `.container` files (systemd doesn't have registry credentials; images are pulled explicitly)
- Proxy uses `Restart=on-failure` (clean stop won't restart loop); apps/accessories use `Restart=always`
- `ArgParser` converts `podman run` flags to Quadlet INI directives

## Test plan

- [x] All 137 unit tests pass (307 assertions)
- [x] Tests cover both Quadlet-enabled and Quadlet-disabled paths
- [x] Quadlet E2E integration test (`quadlet_deploy_test.rb`)
- [x] Existing non-Quadlet integration test still passes
- [ ] Manual deploy test on a real server with `x-quadlet: true`