### PR TITLE
Upgrade to Kamal 2.12.0

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@
 
 - **Gem name**: `kamal_podman`
 - **Current version**: 0.1.0
-- **Pinned Kamal version**: 2.10.1 (exact pin — any Kamal update may break overrides)
+- **Pinned Kamal version**: 2.12.0 (exact pin — any Kamal update may break overrides)
 - **License**: MIT
 - **Ruby**: >= 3.0.0
 
@@ -50,7 +50,7 @@ For commands where Podman's syntax genuinely differs from Docker, individual met
 | `commands/app/logging.rb` | Podman `logs` needs `2>&1` and different flag handling |
 | `configuration/registry.rb` | Podman requires explicit `docker.io/` prefix (Docker assumes it) |
 | `configuration/proxy/boot.rb` | Same `docker.io/` prefix for kamal-proxy image |
-| `cli/main.rb` | Replaces server bootstrap to check for Podman, not Docker |
+| `cli/server.rb` | Replaces `bootstrap` to check for Podman, not install Docker |
 
 **Safety net:** `test/auto_discovery_test.rb` dynamically iterates all `Kamal::Commands::Base` subclasses and verifies `docker()` returns a podman command. This catches any new Kamal class added in a future version that doesn't work with the base swap.
 
@@ -62,7 +62,6 @@ For commands where Podman's syntax genuinely differs from Docker, individual met
 | `KamalPodman::Commands::Podman` | Podman system commands (`installed?`, `running?`, `create_network`) |
 | `KamalPodman::Commands::Builder` | Podman-based builder with validation (rejects remote/multi-arch/cloud) |
 | `KamalPodman::Commands::Builder::Local` | `podman build` + `podman push` (stubs out buildx lifecycle) |
-| `KamalPodman::Cli::Server` | Podman-aware server bootstrap (checks for Podman, not Docker) |
 
 ### Podman-Specific Differences from Docker
 
@@ -81,8 +80,6 @@ lib/
     version.rb                 # VERSION constant
     override.rb                # Replaces global KAMAL constant
     commander.rb               # Custom Commander subclass
-    cli/
-      server.rb                # Podman-aware server bootstrap
     commands/
       podman.rb                # Podman system commands
       builder.rb               # Builder orchestrator
@@ -91,9 +88,9 @@ lib/
   overrides/                   # NOT autoloaded by Zeitwerk — loaded manually via Dir.glob
     kamal/
       cli/
-        main.rb                # Replaces server subcommand
+        server.rb              # Podman-aware bootstrap (patched onto Kamal::Cli::Server)
       commands/
-        base.rb                # Layer 1: docker()→podman() + container_id_for
+        base.rb                # Layer 1: docker() → podman()
         app/
           logging.rb           # Layer 2: Podman-specific logs/follow_logs
         prune.rb               # Layer 2: Podman-specific prune commands
@@ -135,9 +132,11 @@ Use Docker Compose to spin up 4 services:
 - **registry**: Local HTTP registry (registry:2) with htpasswd auth on port 5000
 - **shared**: Generates SSH keys and TLS certs
 
-Run from host (not from inside containers):
+Run from host (not from inside containers). Ruby only executes the first script argument —
+passing both files runs `main_test.rb` alone and silently skips `deploy_test.rb`:
 ```bash
-ruby -Itest test/integration/main_test.rb test/integration/deploy_test.rb
+ruby -Itest test/integration/main_test.rb
+ruby -Itest test/integration/deploy_test.rb
 ```
 
 The test framework's `setup` hook handles `docker compose up/down` automatically.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     kamal_podman (0.1.0)
       activesupport (>= 7.0)
-      kamal (= 2.10.1)
+      kamal (= 2.12.0)
       zeitwerk (>= 2.6.18, < 3.0)
 
 GEM
@@ -63,7 +63,7 @@ GEM
       rdoc (>= 4.0.0)
       reline (>= 0.4.2)
     json (2.9.0)
-    kamal (2.10.1)
+    kamal (2.12.0)
       activesupport (>= 7.0)
       base64 (~> 0.2)
       bcrypt_pbkdf (~> 1.0)

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Please note that Kamal Podman is still under development. Not all features are f
 Incomplete Features: Some Kamal commands might not translate directly to Podman's API, leading to partial functionality or differing behavior.
 Experimental: The gem is in its experimental phase, and you might encounter bugs or unexpected behaviors.
 
-Kamal base version: `2.10.1`
+Kamal base version: `2.12.0`
 
 ## Installation: 
 

--- a/kamal_podman.gemspec
+++ b/kamal_podman.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |spec|
   spec.files = Dir["lib/**/*", "LICENSE.txt", "README.md"]
   spec.executables = %w[kamal-podman]
 
-  spec.add_dependency "kamal", "2.10.1"
+  spec.add_dependency "kamal", "2.12.0"
   spec.add_dependency "zeitwerk", ">= 2.6.18", "< 3.0"
   spec.add_dependency "activesupport", ">= 7.0"
 

--- a/lib/kamal_podman.rb
+++ b/lib/kamal_podman.rb
@@ -7,7 +7,7 @@ require "kamal"
 module KamalPodman
   class Error < StandardError; end
 
-  KAMAL_COMPATIBLE_VERSION = "2.10.1"
+  KAMAL_COMPATIBLE_VERSION = "2.12.0"
 
   unless Kamal::VERSION == KAMAL_COMPATIBLE_VERSION
     warn "[kamal_podman] WARNING: Built for Kamal #{KAMAL_COMPATIBLE_VERSION}, " \

--- a/lib/overrides/kamal/cli/main.rb
+++ b/lib/overrides/kamal/cli/main.rb
@@ -1,6 +1,11 @@
 # frozen_string_literal: true
 
+# Re-describe the `server` subcommand without swapping the registered class. Kamal::Cli::Base
+# #command resolves the running class through Kamal::Cli::Main.subcommand_classes, so it has
+# to stay Kamal::Cli::Server — the Podman bootstrap is patched onto that class instead
+# (see overrides/kamal/cli/server.rb).
 Kamal::Cli::Main.class_eval do
   desc "server", "Bootstrap servers with curl and Podman"
-  subcommand "server", KamalPodman::Cli::Server
+  subcommand "server", Kamal::Cli::Server
+  subcommands.uniq!
 end

--- a/lib/overrides/kamal/cli/server.rb
+++ b/lib/overrides/kamal/cli/server.rb
@@ -1,9 +1,15 @@
 # frozen_string_literal: true
 
-class KamalPodman::Cli::Server < Kamal::Cli::Server
+# Patch bootstrap on Kamal::Cli::Server itself rather than registering a subclass as the
+# `server` subcommand. `kamal-podman setup` reaches bootstrap through Thor's namespace
+# lookup ("kamal:cli:server:bootstrap"), which resolves to Kamal::Cli::Server and would
+# bypass a subclass entirely. Kamal::Cli::Base#command also looks the running class up in
+# Kamal::Cli::Main.subcommand_classes, so swapping that registration breaks every command
+# wrapped in `modify`.
+Kamal::Cli::Server.class_eval do
   desc "bootstrap", "Set up Podman to run Kamal apps"
   def bootstrap
-    with_lock do
+    modify(lock: true) do
       missing = []
 
       on(KAMAL.hosts) do |host|

--- a/lib/overrides/kamal/commands/base.rb
+++ b/lib/overrides/kamal/commands/base.rb
@@ -8,8 +8,4 @@ Kamal::Commands::Base.class_eval do
   def podman(*args)
     args.compact.unshift :podman
   end
-
-  def container_id_for(container_name:, only_running: false)
-    podman :container, :ls, *("--all" unless only_running), "--filter", "'name=^#{container_name}$'", "--quiet"
-  end
 end

--- a/test/integration/main_test.rb
+++ b/test/integration/main_test.rb
@@ -29,10 +29,11 @@ class MainTest < IntegrationTest
     puts "DEBUG: kamal server --help for gem loading test: #{result.inspect}" if ENV["DEBUG"]
     assert_match /podman/i, result.downcase
 
-    # Test that KamalPodman::Cli::Server exists
-    result = deployer_exec("ruby -e 'require \"kamal_podman\"; puts KamalPodman::Cli::Server.class'", capture: true)
-    puts "DEBUG: KamalPodman::Cli::Server check: #{result.inspect}" if ENV["DEBUG"]
-    assert_match /Class/, result
+    # Test that the bootstrap override is applied to Kamal::Cli::Server itself, which is
+    # what `kamal-podman setup` resolves to via Thor's namespace lookup
+    result = deployer_exec("ruby -e 'require \"kamal_podman\"; puts Kamal::Cli::Server.commands[\"bootstrap\"].description'", capture: true)
+    puts "DEBUG: bootstrap description check: #{result.inspect}" if ENV["DEBUG"]
+    assert_match /podman/i, result.downcase
   end
 
   test "config" do

--- a/test/overrides_test.rb
+++ b/test/overrides_test.rb
@@ -158,7 +158,7 @@ class ProxyOverrideTest < ActiveSupport::TestCase
 
   test "info" do
     assert_equal \
-      "podman ps --filter name=^kamal-proxy$",
+      "podman ps --filter 'name=^kamal-proxy$'",
       new_command.info.join(" ")
   end
 
@@ -361,8 +361,51 @@ class ConfigurationOverrideTest < ActiveSupport::TestCase
     end
 end
 
-class CliMainOverrideTest < ActiveSupport::TestCase
-  test "server subcommand" do
-    assert_equal KamalPodman::Cli::Server, Kamal::Cli::Main.subcommand_classes["server"]
+class CliServerOverrideTest < ActiveSupport::TestCase
+  # `kamal-podman setup` invokes "kamal:cli:server:bootstrap", which Thor resolves by
+  # namespace rather than through Kamal::Cli::Main's subcommand registration. Both routes
+  # have to land on the same podman-aware class, and Kamal::Cli::Base#command requires that
+  # class to be the one registered as the `server` subcommand.
+  test "server subcommand is the class the setup namespace resolves to" do
+    klass, command = Thor::Util.find_class_and_command_by_namespace("kamal:cli:server:bootstrap")
+
+    assert_equal Kamal::Cli::Server, klass
+    assert_equal "bootstrap", command
+    assert_equal klass, Kamal::Cli::Main.subcommand_classes["server"]
+  end
+
+  test "bootstrap is described in terms of podman" do
+    assert_match(/podman/i, Kamal::Cli::Server.commands["bootstrap"].description)
+  end
+
+  test "server subcommand is described in terms of podman exactly once" do
+    assert_match(/podman/i, Kamal::Cli::Main.commands["server"].description)
+    assert_equal [ "server" ], Kamal::Cli::Main.subcommands.select { |name| name == "server" }
+  end
+
+  test "bootstrap checks for podman rather than installing docker" do
+    error = assert_raises(KamalPodman::Error) do
+      stdouted { Kamal::Cli::Server.start([ "bootstrap", "-c", "test/fixtures/deploy_simple.yml" ]) }
+    end
+
+    assert_match(/Podman is not installed/, error.message)
+  end
+
+  test "setup bootstraps podman before anything else" do
+    error = assert_raises(KamalPodman::Error) do
+      stdouted { Kamal::Cli::Main.start([ "setup", "-c", "test/fixtures/deploy_simple.yml" ]) }
+    end
+
+    assert_match(/Podman is not installed/, error.message)
+  end
+
+  test "bootstrap runs the podman check on every host" do
+    SSHKit::Backend::Printer.any_instance.stubs(:execute).returns(true)
+    SSHKit::Backend::Printer.any_instance.expects(:execute)
+      .with(:podman, "-v", raise_on_non_zero_exit: false)
+      .twice
+      .returns(true)
+
+    stdouted { Kamal::Cli::Server.start([ "bootstrap", "-c", "test/fixtures/deploy_simple.yml" ]) }
   end
 end


### PR DESCRIPTION
Brings the pin up from `2.10.1` (released 2025-12-16) to `2.12.0` (2026-06-18) — two minor releases, 106 commits, 50 files and +1082/−276 in Kamal's `lib/`.

## The Layer 1 swap held up

No new `Kamal::Commands::Base` subclasses were added in either release, and `prune.rb`, `configuration/registry.rb`, and `configuration/proxy/boot.rb` were untouched upstream. Against 2.12.0 the existing suite went 61/62 before any changes here.

## Changes

**Dropped the `container_id_for` override.** Upstream `7e1467ff` ("Quote filter names in docker commands") added the exact quoting this override existed to provide, so the base `docker()` → `podman()` swap now produces an identical command. The proxy `info` expectation is updated for the same upstream change.

**Fixed `kamal-podman setup`.** It was crashing:

```
SSHKit::Runner::ExecuteError: undefined method 'superuser?' for an instance of KamalPodman::Commands::Podman
```

`Kamal::Cli::Main#setup` reaches bootstrap through Thor's namespace lookup (`invoke "kamal:cli:server:bootstrap"`), which resolves to `Kamal::Cli::Server` and bypassed the `KamalPodman::Cli::Server` subcommand registration entirely — so `setup` ran Docker's bootstrap against the Podman commander. `kamal-podman server bootstrap` was unaffected, which is why the integration suite never caught it.

Bootstrap is now patched onto `Kamal::Cli::Server` itself rather than living on a subclass. That is load-bearing beyond the namespace lookup: `Kamal::Cli::Base#command` resolves the running class through `Kamal::Cli::Main.subcommand_classes` and does `find { ... }[0]`, so registering a subclass there raises `NoMethodError` on `nil` for every command wrapped in 2.12.0's new `modify`. The `server` subcommand registration stays stock; only its description is re-set to mention Podman.

**`with_lock` → `modify(lock: true)`** in bootstrap, so it participates in 2.12.0's new output logging framework (`Kamal::Output::*`, OTel/file backends), which every mutating upstream command was rewritten to use.

## Verified as no-ops for Podman

Configurable `--restart` policy (Podman accepts all of `no`/`always`/`unless-stopped`/`on-failure[:N]`); `stop_timeout` → `-t N`; `ssh_config_args` and `forward_agent`; ERB `trim_mode`; `git gc --auto` in builder clone (the local builder doesn't include `Clone`); local-registry reorder in `cli/build.rb` (`registry.local?` matches `^localhost[:$]`, and the `docker.io` default returns false there).

## Test results

| Suite | Result |
|---|---|
| Unit | 67 runs, 126 assertions, 0 failures, 0 errors |
| Integration `main_test.rb` | 6 runs, 20 assertions, 0 failures, 0 errors |
| Integration `deploy_test.rb` | 2 runs, 6 assertions, 0 failures, 0 errors |
| RuboCop | 25 files, no offenses |

Five new tests cover the bootstrap routing, including one that drives `Kamal::Cli::Main.start(["setup", ...])` end to end — it reproduces the `superuser?` crash against the old structure.

## Notes

- `kamal-proxy` minimum moved `v0.9.0` → `v0.9.2`; the deploy integration test boots the proxy on Podman-in-Docker successfully, so the existing `NET_BIND_SERVICE` workaround still holds.
- `kamal-podman setup` still prints "Ensure Docker is installed..." — that string is inside `Kamal::Cli::Main#setup`, and overriding it would mean copying the whole method body on every upgrade. Left as-is.
- The gem's own `VERSION` is untouched at `0.1.0`.
- CLAUDE.md's integration command ran `main_test.rb` only — `ruby -Itest a.rb b.rb` passes `b.rb` as ARGV, silently skipping `deploy_test.rb`. Documented as two invocations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)