### PR TITLE
Fix podman-invalid command syntax and add a syntax safety net

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,13 +46,28 @@ For commands where Podman's syntax genuinely differs from Docker, individual met
 
 | Override file | Why it exists |
 |---|---|
-| `commands/prune.rb` | Podman has no `docker image prune --filter`; rewrites to `podman image ls` + shell piping |
+| `commands/prune.rb` | Podman has no `docker image prune --filter`; rewrites to `podman image ls` + shell piping. Also drops `status=dead` |
+| `commands/app.rb` | `ACTIVE_DOCKER_STATUSES` drops `restarting` — not a Podman container state |
 | `commands/app/logging.rb` | Podman `logs` needs `2>&1` and different flag handling |
+| `commands/base.rb` | Layer 1 swap, plus `ensure_docker_installed` drops the `buildx` probe |
+| `commands/registry.rb` | Local registry image needs the explicit `docker.io/library/` prefix |
 | `configuration/registry.rb` | Podman requires explicit `docker.io/` prefix (Docker assumes it) |
 | `configuration/proxy/boot.rb` | Same `docker.io/` prefix for kamal-proxy image |
 | `cli/server.rb` | Replaces `bootstrap` to check for Podman, not install Docker |
 
-**Safety net:** `test/auto_discovery_test.rb` dynamically iterates all `Kamal::Commands::Base` subclasses and verifies `docker()` returns a podman command. This catches any new Kamal class added in a future version that doesn't work with the base swap.
+**Podman rejects some Docker syntax outright.** Container states are the main trap: Docker's
+`restarting`, `dead`, and `stopping` are not valid Podman states, and `podman ps --filter
+status=<invalid>` fails with `unknown container state`. When such a command heads a pipe the
+error goes to stderr and the pipeline still exits 0 — so the failure is silent. Podman also
+has no `buildx` or `context` subcommand.
+
+**Safety nets:** `test/auto_discovery_test.rb` holds two. `AutoDiscoveryTest` iterates all
+`Kamal::Commands::Base` subclasses and verifies `docker()` returns a podman command — this
+catches any new Kamal class that doesn't work with the base swap. `PodmanSyntaxTest` goes
+further: it calls every public command-building method on every command class and asserts the
+emitted string contains no Docker-only syntax (`buildx`, `context`, invalid `status=` filters).
+"Starts with podman" is not the same as "valid podman", and the second test is what catches
+that. Run both after every Kamal upgrade.
 
 ### Key Classes
 
@@ -90,10 +105,12 @@ lib/
       cli/
         server.rb              # Podman-aware bootstrap (patched onto Kamal::Cli::Server)
       commands/
-        base.rb                # Layer 1: docker() → podman()
+        base.rb                # Layer 1: docker() → podman(); no-buildx install check
+        app.rb                 # Layer 2: active container states (no `restarting`)
         app/
           logging.rb           # Layer 2: Podman-specific logs/follow_logs
-        prune.rb               # Layer 2: Podman-specific prune commands
+        prune.rb               # Layer 2: Podman-specific prune commands (no `dead`)
+        registry.rb            # Layer 2: local registry image with docker.io prefix
       configuration/
         registry.rb            # Default registry = docker.io
         proxy/

--- a/lib/kamal_podman/commands/builder.rb
+++ b/lib/kamal_podman/commands/builder.rb
@@ -5,8 +5,10 @@ class KamalPodman::Commands::Builder < Kamal::Commands::Builder
     @local ||= KamalPodman::Commands::Builder::Local.new(config)
   end
 
-  def ensure_docker_installed
-    podman "--version"
+  # Upstream strips the Kamal namespace to label the builder; ours lives under KamalPodman,
+  # so without this `kamal-podman build details` reports the whole class path.
+  def name
+    target.class.to_s.remove("KamalPodman::Commands::Builder::").underscore.inquiry
   end
 
   def validate!
@@ -20,6 +22,13 @@ class KamalPodman::Commands::Builder < Kamal::Commands::Builder
 
     if config.builder.cloud?
       raise KamalPodman::Error, "Podman does not support cloud builders. Remove the cloud driver from your builder configuration."
+    end
+
+    # Pack builds through the `pack` CLI, which writes the image into the Docker daemon.
+    # The subsequent push would look for it in Podman's store and not find it, so reject
+    # this at configuration time rather than failing mid-deploy.
+    if config.builder.pack?
+      raise KamalPodman::Error, "Podman does not support pack (buildpack) builders. Remove the `pack` option from your builder configuration."
     end
   end
 end

--- a/lib/kamal_podman/commands/builder/local.rb
+++ b/lib/kamal_podman/commands/builder/local.rb
@@ -13,6 +13,12 @@ class KamalPodman::Commands::Builder::Local < Kamal::Commands::Builder::Base
       podman(:push, config.absolute_image)
   end
 
+  # Upstream lists build backends with `docker context ls && docker buildx ls`; Podman has
+  # neither subcommand. `podman version` is the closest equivalent diagnostic.
+  def info
+    podman :version
+  end
+
   def create; end
   def inspect_builder; end
   def remove; end

--- a/lib/overrides/kamal/commands/app.rb
+++ b/lib/overrides/kamal/commands/app.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+# Docker treats "restarting" as an active container state; Podman has no such state and
+# rejects the filter outright:
+#
+#   $ podman ps --filter status=restarting
+#   Error: unknown container state: restarting: invalid argument
+#
+# The error goes to stderr, so `current_running_container_id` and `current_running_version`
+# silently return empty instead of failing — which reads to Kamal as "nothing is running".
+#
+# Constants assigned inside a class_eval block land in the block's lexical scope, not the
+# receiver, so this has to go through const_set.
+Kamal::Commands::App.send(:remove_const, :ACTIVE_DOCKER_STATUSES)
+Kamal::Commands::App.const_set(:ACTIVE_DOCKER_STATUSES, [ :running ].freeze)

--- a/lib/overrides/kamal/commands/base.rb
+++ b/lib/overrides/kamal/commands/base.rb
@@ -8,4 +8,11 @@ Kamal::Commands::Base.class_eval do
   def podman(*args)
     args.compact.unshift :podman
   end
+
+  # Upstream pairs the daemon check with `docker buildx version`. Podman has no buildx, so
+  # the swapped command always fails. Only KAMAL.builder calls this today, but it is public
+  # and inherited by every command class, so fix it at the root.
+  def ensure_docker_installed
+    podman "--version"
+  end
 end

--- a/lib/overrides/kamal/commands/prune.rb
+++ b/lib/overrides/kamal/commands/prune.rb
@@ -16,6 +16,13 @@ Kamal::Commands::Prune.class_eval do
   end
 
   private
+    # Podman rejects `status=dead` ("unknown container state"). Because the failing command
+    # is the head of a pipe, the pipeline still exits 0 — so pruning silently removed
+    # nothing and reported success. Podman's terminal states here are created and exited.
+    def stopped_containers_filters
+      [ "created", "exited" ].flat_map { |status| [ "--filter", "status=#{status}" ] }
+    end
+
     def active_image_list
       # Pull the images that are used by any containers
       # Append repo:latest - to avoid deleting the latest tag

--- a/lib/overrides/kamal/commands/registry.rb
+++ b/lib/overrides/kamal/commands/registry.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+Kamal::Commands::Registry.class_eval do
+  # Same reason as configuration/registry.rb: Podman only resolves a bare `registry:3` when
+  # the host happens to set unqualified-search-registries. Name the image explicitly.
+  def setup(registry_config: nil)
+    registry_config ||= config.registry
+
+    combine \
+      podman(:start, "kamal-docker-registry"),
+      podman(:run, "--detach", "-p", "127.0.0.1:#{registry_config.local_port}:5000", "--name", "kamal-docker-registry", "docker.io/library/registry:3"),
+      by: "||"
+  end
+end

--- a/test/auto_discovery_test.rb
+++ b/test/auto_discovery_test.rb
@@ -1,5 +1,8 @@
 require "test_helper"
 
+# Safety nets for Kamal upgrades. The binary swap on Kamal::Commands::Base means new upstream
+# commands become podman commands for free — but "starts with podman" is not the same as
+# "valid podman". These tests check both halves.
 class AutoDiscoveryTest < ActiveSupport::TestCase
   setup do
     @config = {
@@ -42,4 +45,100 @@ class AutoDiscoveryTest < ActiveSupport::TestCase
 
     assert_empty uncovered, "The following classes are not covered by docker->podman overrides:\n#{uncovered.join("\n")}"
   end
+end
+
+# Docker syntax that Podman rejects outright. Swapping the binary is not enough for these —
+# each needs a Layer 2 override. Verified against real podman; the container-state errors
+# read "Error: unknown container state: <state>: invalid argument".
+class PodmanSyntaxTest < ActiveSupport::TestCase
+  INVALID_SYNTAX = {
+    /\bpodman buildx\b/ => "podman has no buildx",
+    /\bpodman context\b/ => "podman has no context command",
+    /status=restarting\b/ => "not a podman container state",
+    /status=dead\b/ => "not a podman container state",
+    /status=stopping\b/ => "not a podman container state"
+  }
+
+  setup do
+    @config = Kamal::Configuration.new({
+      service: "app", image: "dhh/app", registry: { "username" => "user", "password" => "pw" },
+      servers: [ "1.1.1.1" ], builder: { "arch" => "amd64" },
+      accessories: { "db" => { "image" => "mysql:8.0", "host" => "1.1.1.1", "port" => "3306" } }
+    }, version: "999")
+  end
+
+  test "no command emits docker-only syntax that podman rejects" do
+    offenders = []
+
+    each_emitted_command do |source, command|
+      INVALID_SYNTAX.each do |pattern, reason|
+        offenders << "#{source}: #{reason}\n    #{command}" if command.match?(pattern)
+      end
+    end
+
+    assert_empty offenders, "Commands using syntax podman rejects:\n#{offenders.join("\n")}"
+  end
+
+  test "sweep actually reaches the commands it claims to cover" do
+    sources = []
+    each_emitted_command { |source, _| sources << source }
+
+    # Guard against the sweep silently degrading to nothing if an upstream signature changes
+    assert_operator sources.size, :>=, 50, "Sweep only collected #{sources.size} commands"
+    %w[App Accessory Proxy Prune Registry Builder].each do |label|
+      assert sources.any? { |source| source.start_with?("#{label}#") }, "Sweep never reached #{label}"
+    end
+  end
+
+  private
+    def command_instances
+      {
+        "App" => Kamal::Commands::App.new(@config, role: @config.role(:web), host: "1.1.1.1"),
+        "Accessory" => Kamal::Commands::Accessory.new(@config, name: :db),
+        "Proxy" => Kamal::Commands::Proxy.new(@config, host: "1.1.1.1"),
+        "Prune" => Kamal::Commands::Prune.new(@config),
+        "Registry" => Kamal::Commands::Registry.new(@config),
+        "Lock" => Kamal::Commands::Lock.new(@config),
+        "Auditor" => Kamal::Commands::Auditor.new(@config),
+        "Server" => Kamal::Commands::Server.new(@config),
+        "Builder" => KamalPodman::Commands::Builder.new(@config)
+      }
+    end
+
+    # Calls every public command-building method, filling required positional args with a
+    # version-shaped string. Methods needing other shapes just raise and are skipped.
+    def each_emitted_command
+      command_instances.each do |label, instance|
+        methods_for(instance).each do |method_name|
+          method = begin
+            instance.method(method_name)
+          rescue NameError
+            next
+          end
+          next unless method.owner.to_s.start_with?("Kamal", "KamalPodman")
+
+          args = Array.new(method.parameters.count { |type, _| type == :req }, "999")
+          kwargs = method.parameters.filter_map { |type, name| [ name, stub_value_for(name) ] if type == :keyreq }.to_h
+
+          begin
+            result = kwargs.any? ?
+              instance.public_send(method_name, *args, **kwargs) :
+              instance.public_send(method_name, *args)
+          rescue StandardError
+            next
+          end
+
+          command = Array(result).flatten.join(" ")
+          yield "#{label}##{method_name}", command if command.include?("podman")
+        end
+      end
+    end
+
+    def methods_for(instance)
+      (instance.public_methods(false) + instance.class.superclass.public_instance_methods(false)).uniq
+    end
+
+    def stub_value_for(parameter_name)
+      parameter_name == :retain ? 1 : "999"
+    end
 end

--- a/test/commands_test.rb
+++ b/test/commands_test.rb
@@ -98,9 +98,30 @@ class BuilderCommandsTest < ActiveSupport::TestCase
     assert_match(/cloud builders/, error.message)
   end
 
+  # pack builds through the pack CLI into the Docker daemon; the push would then look for
+  # the image in podman's store and not find it. Reject at config time, not mid-deploy.
+  test "validate! raises for pack builder" do
+    error = assert_raises(KamalPodman::Error) { pack_builder.validate! }
+    assert_match(/pack \(buildpack\) builders/, error.message)
+  end
+
+  test "pack builder would otherwise fall through to the docker pack target" do
+    assert_equal Kamal::Commands::Builder::Pack, pack_builder.target.class
+  end
+
+  test "name reports the podman builder without its namespace" do
+    assert_equal "local", new_command.name
+    assert_predicate new_command.name, :local?
+  end
+
   private
     def new_command
       KamalPodman::Commands::Builder.new(Kamal::Configuration.new(@config, version: "999"))
+    end
+
+    def pack_builder
+      config = @config.merge(builder: { "arch" => "amd64", "pack" => { "builder" => "heroku/builder:24", "buildpacks" => [ "heroku/ruby" ] } })
+      KamalPodman::Commands::Builder.new(Kamal::Configuration.new(config, version: "999"))
     end
 end
 
@@ -132,6 +153,11 @@ class BuilderLocalCommandsTest < ActiveSupport::TestCase
 
   test "remove is a no-op" do
     assert_nil new_command.remove
+  end
+
+  # Upstream is `docker context ls && docker buildx ls`; podman has neither subcommand.
+  test "info reports podman version instead of buildx builders" do
+    assert_equal [ :podman, :version ], new_command.info
   end
 
   private

--- a/test/integration/deploy_test.rb
+++ b/test/integration/deploy_test.rb
@@ -14,6 +14,18 @@ class DeployTest < IntegrationTest
     assert_container_running host: :vm1, name: "kamal-proxy"
   end
 
+  # Exercises Kamal's own container lookup rather than querying podman directly. That path
+  # runs through `podman ps --filter status=...`, which silently returned nothing when the
+  # filter included docker-only states — so a deploy could not see what was already running.
+  test "app version sees the running container through kamal's own lookup" do
+    version = latest_app_version
+
+    kamal :deploy
+
+    output = kamal :app, :version, capture: true
+    assert_match /#{version}/, output
+  end
+
   test "deploy uses podman not docker" do
     output = kamal :deploy, "--verbose", capture: true
 

--- a/test/overrides_test.rb
+++ b/test/overrides_test.rb
@@ -136,6 +136,53 @@ class AppLoggingOverrideTest < ActiveSupport::TestCase
     end
 end
 
+# Docker treats "restarting" as an active state; podman rejects the filter and writes the
+# error to stderr, so these lookups returned empty instead of failing — Kamal then concluded
+# nothing was running during boot, stop, logs and version.
+class AppActiveStatusOverrideTest < ActiveSupport::TestCase
+  setup do
+    @config = {
+      service: "app", image: "dhh/app", registry: { "username" => "user", "password" => "pw" },
+      servers: [ "1.1.1.1" ], builder: { "arch" => "amd64" }
+    }
+  end
+
+  test "active statuses exclude restarting" do
+    assert_equal [ :running ], Kamal::Commands::App::ACTIVE_DOCKER_STATUSES
+  end
+
+  test "current_running_container_id filters on running only" do
+    result = new_command.current_running_container_id.join(" ")
+    assert_match(/--filter status=running/, result)
+    assert_no_match(/status=restarting/, result)
+  end
+
+  test "current_running_version filters on running only" do
+    assert_no_match(/status=restarting/, new_command.current_running_version.join(" "))
+  end
+
+  test "stop filters on running only" do
+    assert_no_match(/status=restarting/, new_command.stop.join(" "))
+  end
+
+  private
+    def new_command
+      config = Kamal::Configuration.new(@config, version: "999")
+      Kamal::Commands::App.new(config, role: config.role(:web), host: "1.1.1.1")
+    end
+end
+
+class BaseInstallCheckOverrideTest < ActiveSupport::TestCase
+  test "ensure_docker_installed drops the buildx probe podman cannot satisfy" do
+    config = Kamal::Configuration.new({
+      service: "app", image: "dhh/app", registry: { "username" => "user", "password" => "pw" },
+      servers: [ "1.1.1.1" ], builder: { "arch" => "amd64" }
+    }, version: "999")
+
+    assert_equal "podman --version", Kamal::Commands::Base.new(config).ensure_docker_installed.flatten.join(" ")
+  end
+end
+
 class ProxyOverrideTest < ActiveSupport::TestCase
   setup do
     @config = {
@@ -188,6 +235,12 @@ class RegistryOverrideTest < ActiveSupport::TestCase
       new_command.logout.join(" ")
   end
 
+  test "local registry setup names the image explicitly" do
+    result = new_command.setup.join(" ")
+    assert_match(%r{docker\.io/library/registry:3}, result)
+    assert_no_match(/ registry:3/, result)
+  end
+
   private
     def new_command
       Kamal::Commands::Registry.new(Kamal::Configuration.new(@config))
@@ -216,12 +269,18 @@ class PruneOverrideTest < ActiveSupport::TestCase
 
   test "app containers" do
     assert_equal \
-      "podman ps -q -a --filter label=service=app --filter status=created --filter status=exited --filter status=dead | tail -n +6 | while read container_id; do podman rm $container_id; done",
+      "podman ps -q -a --filter label=service=app --filter status=created --filter status=exited | tail -n +6 | while read container_id; do podman rm $container_id; done",
       new_command.app_containers(retain: 5).join(" ")
 
     assert_equal \
-      "podman ps -q -a --filter label=service=app --filter status=created --filter status=exited --filter status=dead | tail -n +4 | while read container_id; do podman rm $container_id; done",
+      "podman ps -q -a --filter label=service=app --filter status=created --filter status=exited | tail -n +4 | while read container_id; do podman rm $container_id; done",
       new_command.app_containers(retain: 3).join(" ")
+  end
+
+  # Podman rejects status=dead. As the head of a pipe its failure is swallowed — the
+  # pipeline still exits 0, so pruning reported success while removing nothing.
+  test "app containers omits the docker-only dead status" do
+    assert_no_match(/status=dead/, new_command.app_containers(retain: 5).join(" "))
   end
 
   private


### PR DESCRIPTION
Follow-up to #11. `auto_discovery_test` asserted only that `docker()` returned a `:podman` array — never that the result was **valid** podman. Four defects lived in that blind spot; two of them silent.

## The silent failure mode

Docker's `restarting` and `dead` are not podman container states:

```
$ podman ps --filter status=restarting
Error: unknown container state: restarting: invalid argument
```

Each failing command heads a pipe, so the error goes to stderr and **the pipeline still exits 0**. Nothing raised, nothing logged.

### 1. Container lookup returned nothing — HIGH

`ACTIVE_DOCKER_STATUSES = [:running, :restarting]` feeds `current_running_container_id`, `current_running_version` and `stop`. With a container genuinely running:

```
with    status=restarting → []
without status=restarting → [cb4bddc2306a]
```

Every call site uses `raise_on_non_zero_exit: false` and `.strip.presence`, so it degraded to `nil`. Affects `app logs`, `app stop`, `app version`, `app exec`, asset bridging (`cli/app/assets.rb:15`), and `cli/app/boot.rb:43` — where **every deploy** detects the currently-running version. Kamal concluded nothing was running.

### 2. `prune containers` was a permanent no-op — HIGH

`stopped_containers_filters` used `created`, `exited`, `dead`. With a real exited container present:

```
prune command       → Error: unknown container state: dead   (exit 0)
without status=dead → 8c234e34e59c
```

Containers accumulated forever while every run reported success.

### 3. `pack` builders bypassed validation — MEDIUM

`validate!` rejected remote, multi-arch and cloud but not `pack?`, so `target` fell through to stock `Kamal::Commands::Builder::Pack`. That builds via the `pack` CLI into the **Docker daemon**, then pushes an image podman's store doesn't have. Now rejected at config time instead of failing mid-deploy.

### 4. `buildx` / `context` — LOW

`Builder#info` emitted `podman context ls && podman buildx ls` (reachable via `build details`); `Base#ensure_docker_installed` emitted `podman buildx version` on all eight non-builder command classes. The latter was latent — only `KAMAL.builder` calls it and we overrode that — but it's a public inherited method one upstream change from firing. Fixed at the root, so the builder-specific override is gone.

Also included: local registry image now `docker.io/library/registry:3` (bare `registry:3` only resolves when the host sets `unqualified-search-registries` — the assumption `configuration/registry.rb` exists to avoid), and `builder.name` reports `local` rather than the full class path.

## The safety net

`PodmanSyntaxTest` calls every public command-building method on every command class and asserts no docker-only syntax survives. **Each fix was confirmed to make it fail when reverted:**

| Fix reverted | Caught |
|---|---|
| `ACTIVE_DOCKER_STATUSES` | `App#stop`, `App#current_running_container_id`, `App#current_running_version` |
| `stopped_containers_filters` | `Prune#app_containers` |
| `Base#ensure_docker_installed` | 7 classes |
| `Builder::Local#info` | `Builder#info` (buildx + context) |

It carries a self-check asserting the sweep still reaches ≥50 commands across all six major classes, so it can't silently degrade to passing on nothing when an upstream signature changes.

The integration suite verified containers via its own `podman ps --filter=name=`, never through Kamal's lookup — which is precisely why these survived. A new deploy test closes that. Reverting the fix produces exactly the silent failure:

```
Expected /c808b68ae975d/ to match "... exit status 0 (successful).\nApp Host: vm1\n\n\n"
```

## Verification

| Suite | Result |
|---|---|
| Unit | 80 runs, 160 assertions, 0 failures |
| Integration `main_test.rb` | 6 runs, 20 assertions, 0 failures |
| Integration `deploy_test.rb` | 3 runs, 8 assertions, 0 failures |
| RuboCop | 27 files, no offenses |

Fixed commands were re-run against real podman: lookup finds the running container, prune finds the exited one, `podman --version` and `podman version` both succeed.

## Note on porting upstream specs

Upstream has ~800 tests to our 80, but wholesale porting would mostly re-verify unmodified Kamal behaviour that upstream's own suite already covers against the pinned gem — and every method we override or add was already tested. The gap was a different *kind* of check, which is what this adds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)